### PR TITLE
Bug fixes and backward compatibility for below v2.4.5 Bagisto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `bagisto/bagisto-api` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add request and response examples to the Swagger/OpenAPI docs for every Returns (RMA) and EU Withdrawal endpoint (shop and admin).
+- Add the request body schema for creating and updating RMA reasons, rules, statuses and custom fields in the Swagger docs.
+
+### Fixed
+
+- Fix GraphQL connection fields (e.g. cart `items { edges }`) failing with `Field "items" of type "Iterable" must not have a sub selection` on some production PHP-FPM servers.
+- Fix RMA settings create and update responses showing a success `message`; the confirmation message is now returned only on delete.
+- Restore backward compatibility with Bagisto cores below 2.4.5 by conditionally registering the EU Withdrawal endpoints only when the core module is present.
+
 ## [2.4.0] - 2026-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add request and response examples to the Swagger/OpenAPI docs for every Returns (RMA) and EU Withdrawal endpoint (shop and admin).
 - Add the request body schema for creating and updating RMA reasons, rules, statuses and custom fields in the Swagger docs.
 
+### Changed
+
+- Drop the hard Redis requirement: the API metadata/schema cache and rate-limit counters now follow the application's `CACHE_STORE` (falling back to `file`), so no separate cache service or extra configuration is needed.
+- Take the cart file-upload size limit from `php.ini` (`upload_max_filesize`) like the rest of Bagisto instead of a package setting, and default how long a staged upload stays valid to the store's session lifetime.
+
 ### Fixed
 
 - Fix GraphQL connection fields (e.g. cart `items { edges }`) failing with `Field "items" of type "Iterable" must not have a sub selection` on some production PHP-FPM servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add request and response examples to the Swagger/OpenAPI docs for every Returns (RMA) and EU Withdrawal endpoint (shop and admin).
 - Add the request body schema for creating and updating RMA reasons, rules, statuses and custom fields in the Swagger docs.
+- Add `redirect` and `redirectUrl` to the place-order response so clients can tell when the shopper must be sent to a payment page before the order exists.
+- Add `minPrice` and `maxPrice` to the storefront category response so REST clients can bound a price-range filter, matching what GraphQL already exposed.
 
 ### Changed
 
@@ -22,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix GraphQL connection fields (e.g. cart `items { edges }`) failing with `Field "items" of type "Iterable" must not have a sub selection` on some production PHP-FPM servers.
 - Fix RMA settings create and update responses showing a success `message`; the confirmation message is now returned only on delete.
 - Restore backward compatibility with Bagisto cores below 2.4.5 by conditionally registering the EU Withdrawal endpoints only when the core module is present.
+- Fix `paymentGatewayUrl` coming back empty for redirect payment methods (Stripe, Razorpay, PayPal Standard, PhonePe), leaving clients with nowhere to send the shopper.
+- Fix selecting PhonePe as the payment method failing with a server error.
+- Fix place order creating an unpaid order when a redirect payment method is selected; it now returns the payment redirect, and the order is created once the gateway confirms payment.
+- Fix `cartToken` in checkout responses returning the customer id (or an empty value for guests) instead of the cart's guest token; it is now the guest token, or null for a signed-in customer.
+- Fix `cartToken` in cart responses returning the cart id instead of the guest token.
+- Fix 30 admin endpoints in the Swagger docs asking for a required path parameter the URL does not contain, such as `method` on list payment methods and `id` on list order comments.
+- Fix Swagger path parameter descriptions exposing internal resource names (e.g. "AdminCart identifier" now reads "Cart ID").
+- Fix the storefront key falling back to a placeholder in the GraphiQL and Swagger docs after `config:cache` or `optimize`; playground settings are now read from configuration, so they survive a cached config.
+- Fix Swagger UI ignoring `API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY`, so the key was never pre-filled there even when the setting was enabled.
+- Fix product image and video URLs being prefixed with an unset `API_URL`, which produced a doubled host on stores that set it.
+- Fix the copy-product endpoint missing its `sourceId` field in the Swagger docs, which left it uncallable from the UI.
+- Fix the Swagger docs demanding a request body on action endpoints that take none (cancel, reopen and close a return, revoke a GDPR request, reopen an RMA, resend an EU withdrawal confirmation).
 
 ## [2.4.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `bagisto/bagisto-api` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.1] - 2026-07-22
 
 ### Added
 
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the request body schema for creating and updating RMA reasons, rules, statuses and custom fields in the Swagger docs.
 - Add `redirect` and `redirectUrl` to the place-order response so clients can tell when the shopper must be sent to a payment page before the order exists.
 - Add `minPrice` and `maxPrice` to the storefront category response so REST clients can bound a price-range filter, matching what GraphQL already exposed.
+- Add `xls` and `xlsx` to every admin export endpoint (`?format=`), matching the formats the admin panel offers; exported values are now guarded against spreadsheet formula injection.
 
 ### Changed
 
 - Drop the hard Redis requirement: the API metadata/schema cache and rate-limit counters now follow the application's `CACHE_STORE` (falling back to `file`), so no separate cache service or extra configuration is needed.
-- Take the cart file-upload size limit from `php.ini` (`upload_max_filesize`) like the rest of Bagisto instead of a package setting, and default how long a staged upload stays valid to the store's session lifetime.
+- Take the cart file-upload size limit from `php.ini` and the staged-upload lifetime from the session lifetime, instead of package settings.
 
 ### Fixed
 
@@ -27,14 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `paymentGatewayUrl` coming back empty for redirect payment methods (Stripe, Razorpay, PayPal Standard, PhonePe), leaving clients with nowhere to send the shopper.
 - Fix selecting PhonePe as the payment method failing with a server error.
 - Fix place order creating an unpaid order when a redirect payment method is selected; it now returns the payment redirect, and the order is created once the gateway confirms payment.
-- Fix `cartToken` in checkout responses returning the customer id (or an empty value for guests) instead of the cart's guest token; it is now the guest token, or null for a signed-in customer.
-- Fix `cartToken` in cart responses returning the cart id instead of the guest token.
+- Fix `cartToken` in cart and checkout responses returning an id instead of the cart's guest token; it is now the guest token, or null for a signed-in customer.
 - Fix 30 admin endpoints in the Swagger docs asking for a required path parameter the URL does not contain, such as `method` on list payment methods and `id` on list order comments.
 - Fix Swagger path parameter descriptions exposing internal resource names (e.g. "AdminCart identifier" now reads "Cart ID").
 - Fix the storefront key falling back to a placeholder in the GraphiQL and Swagger docs after `config:cache` or `optimize`; playground settings are now read from configuration, so they survive a cached config.
 - Fix Swagger UI ignoring `API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY`, so the key was never pre-filled there even when the setting was enabled.
 - Fix product image and video URLs being prefixed with an unset `API_URL`, which produced a doubled host on stores that set it.
-- Fix the copy-product endpoint missing its `sourceId` field in the Swagger docs, which left it uncallable from the UI.
 - Fix the Swagger docs demanding a request body on action endpoints that take none (cancel, reopen and close a return, revoke a GDPR request, reopen an RMA, resend an EU withdrawal confirmation).
 
 ## [2.4.0] - 2026-07-15
@@ -415,6 +414,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Swagger / OpenAPI documentation at `/api/docs` and GraphQL playground at `/graphiql`.
 - Initial documentation and demo links in the README.
 
+[2.4.1]: https://github.com/bagisto/bagisto-api/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/bagisto/bagisto-api/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/bagisto/bagisto-api/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/bagisto/bagisto-api/compare/v2.2.0...v2.3.0

--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ Edit `composer.json` and update the `autoload` section:
 #### Step 4: Install Dependencies
 
 ```bash
-
+# The Laravel bridge and the GraphQL package pull every other API Platform component in at a matching version
 composer require \
   api-platform/laravel:~4.3.8 \
   api-platform/graphql:~4.3.8
 ```
+
+> On Bagisto **2.3.x** (the previous release of this package), API Platform was not on a single aligned version — every component had to be pinned individually (`laravel v4.1.25`, `graphql v4.2.3`, the rest `v4.3.1`). On **2.4.x** the two packages above are all you need.
 
 #### Step 5: Run the installation
 ```bash

--- a/config/api-platform-vendor.php
+++ b/config/api-platform-vendor.php
@@ -150,11 +150,11 @@ return [
         'datetime_format' => 'Y-m-d\TH:i:sP',
     ],
 
-    'cache' => 'redis',
+    'cache' => env('CACHE_STORE', 'file'),
 
     'schema_cache' => [
         'enabled' => true,
-        'store' => 'redis',
+        'store' => env('CACHE_STORE', 'file'),
     ],
 
     'security' => [
@@ -167,7 +167,7 @@ return [
         'admin' => env('RATE_LIMIT_ADMIN', 60),
         'shop' => env('RATE_LIMIT_SHOP', 100),
         'graphql' => env('RATE_LIMIT_GRAPHQL', 100),
-        'cache_driver' => env('RATE_LIMIT_CACHE', 'redis'),
+        'cache_driver' => env('RATE_LIMIT_CACHE', env('CACHE_STORE', 'file')),
         'cache_prefix' => 'api:rate-limit:',
     ],
 

--- a/config/api-platform-vendor.php
+++ b/config/api-platform-vendor.php
@@ -18,12 +18,13 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Webkul\BagistoApi\Exception\InvalidInputException;
 use Webkul\BagistoApi\Exception\ValidationException;
+use Webkul\BagistoApi\Providers\BagistoApiServiceProvider;
 use Webkul\BagistoApi\Serializer\OutputOnlySnakeToCamelNameConverter;
 
 return [
     'title' => '',
     'description' => '',
-    'version' => '1.0.4',
+    'version' => BagistoApiServiceProvider::BAGISTO_API_VERSION,
     'show_webby' => true,
 
     'routes' => [

--- a/config/api-platform.php
+++ b/config/api-platform.php
@@ -152,11 +152,11 @@ return [
         'datetime_format' => 'Y-m-d\TH:i:sP',
     ],
 
-    'cache' => 'redis',
+    'cache' => env('CACHE_STORE', 'file'),
 
     'schema_cache' => [
         'enabled' => true,
-        'store' => 'redis',
+        'store' => env('CACHE_STORE', 'file'),
     ],
 
     'security' => [
@@ -169,7 +169,7 @@ return [
         'admin' => env('RATE_LIMIT_ADMIN', 60),
         'shop' => env('RATE_LIMIT_SHOP', 100),
         'graphql' => env('RATE_LIMIT_GRAPHQL', 100),
-        'cache_driver' => env('RATE_LIMIT_CACHE', 'redis'),
+        'cache_driver' => env('RATE_LIMIT_CACHE', env('CACHE_STORE', 'file')),
         'cache_prefix' => 'api:rate-limit:',
     ],
 

--- a/config/api-platform.php
+++ b/config/api-platform.php
@@ -18,12 +18,13 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Webkul\BagistoApi\Exception\InvalidInputException;
 use Webkul\BagistoApi\Exception\ValidationException;
+use Webkul\BagistoApi\Providers\BagistoApiServiceProvider;
 use Webkul\BagistoApi\Serializer\OutputOnlySnakeToCamelNameConverter;
 
 return [
     'title' => '',
     'description' => '',
-    'version' => '1.0.4',
+    'version' => BagistoApiServiceProvider::BAGISTO_API_VERSION,
     'show_webby' => true,
 
     'routes' => [

--- a/config/storefront.php
+++ b/config/storefront.php
@@ -52,22 +52,4 @@ return [
     */
     'playground_key' => env('STOREFRONT_PLAYGROUND_KEY'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Cart Customizable File Upload
-    |--------------------------------------------------------------------------
-    |
-    | Staging settings for file-type customizable options added to the cart.
-    | The upload endpoint stages the file and returns a token; add-to-cart
-    | resolves the token. A persistent cache driver is required.
-    |
-    */
-    'cart' => [
-        'customizable_file' => [
-            'max_size_kb' => (int) env('STOREFRONT_CART_FILE_MAX_KB', 2048),
-            'ttl_minutes' => (int) env('STOREFRONT_CART_FILE_TTL', 60),
-            'disk' => env('STOREFRONT_CART_FILE_DISK', 'private'),
-            'stage_dir' => 'cart-uploads',
-        ],
-    ],
 ];

--- a/config/storefront.php
+++ b/config/storefront.php
@@ -52,4 +52,18 @@ return [
     */
     'playground_key' => env('STOREFRONT_PLAYGROUND_KEY'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-inject the Playground Key
+    |--------------------------------------------------------------------------
+    |
+    | Pre-fills the playground key in the GraphiQL and Swagger UI headers so a
+    | developer can call the shop API without pasting it. Leave it off on any
+    | publicly reachable environment — it exposes the key to every visitor.
+    |
+    | Example: API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY=true
+    |
+    */
+    'auto_inject_playground_key' => env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false),
+
 ];

--- a/src/Admin/Exports/AdminGridExport.php
+++ b/src/Admin/Exports/AdminGridExport.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Webkul\BagistoApi\Admin\Exports;
+
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class AdminGridExport implements FromArray, ShouldAutoSize, WithHeadings
+{
+    public function __construct(
+        protected array $headings,
+        protected array $rows
+    ) {}
+
+    public function headings(): array
+    {
+        return $this->headings;
+    }
+
+    public function array(): array
+    {
+        return $this->rows;
+    }
+}

--- a/src/Admin/Models/AdminBooking.php
+++ b/src/Admin/Models/AdminBooking.php
@@ -85,19 +85,19 @@ use Webkul\BagistoApi\Admin\State\AdminBookingItemProvider;
         new Get(
             uriTemplate: '/bookings/export',
             provider: AdminBookingExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Sales: Bookings'],
-                summary: 'Export bookings as CSV',
-                description: 'Downloads the bookings datagrid as a CSV file (text/csv attachment) — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Only ?format=csv is supported.',
+                summary: 'Export bookings as csv, xls or xlsx',
+                description: 'Downloads the bookings datagrid as a csv, xls or xlsx file — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Pick the file type with ?format=csv|xls|xlsx (default csv).',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only csv.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV file downloaded (text/csv attachment).', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment.', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks the view permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminCatalogProduct.php
+++ b/src/Admin/Models/AdminCatalogProduct.php
@@ -524,19 +524,19 @@ use Webkul\Product\Models\Product;
         new Get(
             uriTemplate: '/catalog/products/export',
             provider: AdminCatalogProductExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Catalog: Products'],
-                summary: 'Export products as CSV',
-                description: 'Downloads the products datagrid as a CSV file (text/csv attachment) — the same data the admin Catalog → Products Export button produces. Honours the same filters as the listing and exports every matching row, not just the current page. Binary download, not JSON. Only ?format=csv is supported.',
+                summary: 'Export products as csv, xls or xlsx',
+                description: 'Downloads the products datagrid as a csv, xls or xlsx file — the same data the admin Catalog → Products Export button produces. Honours the same filters as the listing and exports every matching row, not just the current page. Binary download, not JSON. Pick the file type with ?format=csv|xls|xlsx (default csv).',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only csv.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV file downloaded (text/csv attachment).', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment.', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks the view permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminCatalogProductCopy.php
+++ b/src/Admin/Models/AdminCatalogProductCopy.php
@@ -34,6 +34,9 @@ use Webkul\BagistoApi\Admin\State\AdminCatalogProductCopyProcessor;
                 tags: ['Admin Catalog: Products'],
                 summary: 'Copy a catalog product',
                 description: 'Duplicates an existing product across all attribute_values, images, inventories, categories and customer_group_prices. Refuses variants (parent_id != null) with HTTP 422. Mirrors Bagisto monolith ProductController::copy. Fires catalog.product.create.before and catalog.product.create.after.',
+                parameters: [
+                    new Model\Parameter('sourceId', 'path', 'ID of the product to copy', true, schema: ['type' => 'integer']),
+                ],
                 requestBody: new Model\RequestBody(
                     required: false,
                     content: new \ArrayObject([

--- a/src/Admin/Models/AdminCmsPage.php
+++ b/src/Admin/Models/AdminCmsPage.php
@@ -259,13 +259,13 @@ use Webkul\BagistoApi\Admin\State\AdminCmsPageWriteProvider;
         new Get(
             uriTemplate: '/cms/pages/export',
             provider: AdminCmsPageExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin CMS'],
-                summary: 'Export CMS pages as CSV',
-                description: 'Downloads the CMS Pages datagrid as a CSV file (`text/csv` attachment) — the same data the admin CMS → Pages "view" listing shows (ID, Page Title, URL Key, Channel, Locale). Honours the same filters as the listing (`id`, `page_title`, `url_key`, `channel`, `locale`). The response is a binary download, not JSON.',
+                summary: 'Export CMS pages as csv, xls or xlsx',
+                description: 'Downloads the CMS Pages datagrid as a csv, xls or xlsx file — the same data the admin CMS → Pages "view" listing shows (ID, Page Title, URL Key, Channel, Locale). Honours the same filters as the listing (`id`, `page_title`, `url_key`, `channel`, `locale`). The response is a binary download, not JSON.',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only `csv` is supported.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: `csv`, `xls` or `xlsx`. Defaults to `csv`.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                     new Model\Parameter('id', 'query', 'Filter by CMS page ID.', false, schema: ['type' => 'integer']),
                     new Model\Parameter('page_title', 'query', 'Partial page title match.', false, schema: ['type' => 'string']),
                     new Model\Parameter('url_key', 'query', 'Partial url_key match.', false, schema: ['type' => 'string']),
@@ -274,16 +274,16 @@ use Webkul\BagistoApi\Admin\State\AdminCmsPageWriteProvider;
                 ],
                 responses: [
                     '200' => new Model\Response(
-                        description: 'The CMS pages CSV file is downloaded (text/csv attachment).',
+                        description: 'The CMS pages export file is downloaded as an attachment.',
                         content: new \ArrayObject([
-                            'text/csv' => [
-                                'schema' => ['type' => 'string', 'format' => 'binary'],
-                            ],
+                            'text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']],
+                            'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']],
+                            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']],
                         ]),
                     ),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminEuWithdrawal.php
+++ b/src/Admin/Models/AdminEuWithdrawal.php
@@ -29,13 +29,110 @@ use Webkul\BagistoApi\Admin\State\AdminEuWithdrawalWriteProvider;
             uriTemplate: '/eu-withdrawals',
             provider: AdminEuWithdrawalCollectionProvider::class,
             paginationEnabled: false,
-            openapi: new Model\Operation(tags: ['Admin Sales: EU Withdrawal'], summary: 'List EU right-of-withdrawal declarations', description: 'Filters: order_increment_id (LIKE), customer_email (LIKE), status (received|refunded|declined), channel_code, received_at_from/to, confirmation_sent_at_from/to. Sort: id (default desc), received_at, status. Permission: sales.eu_withdrawals.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: EU Withdrawal'],
+                summary: 'List EU right-of-withdrawal declarations',
+                description: 'Filters: order_increment_id (LIKE), customer_email (LIKE), status (received|refunded|declined), channel_code, received_at_from/to, confirmation_sent_at_from/to. Sort: id (default desc), received_at, status. Permission: sales.eu_withdrawals.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The withdrawal declarations.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'data' => [
+                                        [
+                                            'id' => 7,
+                                            'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                            'orderId' => 12,
+                                            'orderIncrementId' => '000000012',
+                                            'customerId' => 5,
+                                            'customerName' => 'Jane Doe',
+                                            'customerEmail' => 'jane@example.com',
+                                            'isGuest' => false,
+                                            'channelId' => 1,
+                                            'channelCode' => 'default',
+                                            'locale' => 'en',
+                                            'reasonText' => 'Changed my mind.',
+                                            'status' => 'received',
+                                            'receivedAt' => '2026-07-20T09:00:00+00:00',
+                                            'confirmationSentAt' => '2026-07-20T09:00:05+00:00',
+                                            'finalConfirmationSentAt' => null,
+                                            'confirmationError' => null,
+                                            'declinedAt' => null,
+                                            'declinedReason' => null,
+                                            'declinedByUserId' => null,
+                                            'declinedByName' => null,
+                                            'refundedAt' => null,
+                                            'refundedByUserId' => null,
+                                            'refundedByName' => null,
+                                            'refundNote' => null,
+                                            'message' => null,
+                                            'createdAt' => '2026-07-20T09:00:00+00:00',
+                                            'updatedAt' => '2026-07-20T09:00:05+00:00',
+                                        ],
+                                    ],
+                                    'meta' => [
+                                        'currentPage' => 1,
+                                        'perPage' => 10,
+                                        'lastPage' => 1,
+                                        'total' => 1,
+                                        'from' => 1,
+                                        'to' => 1,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Get(
             uriTemplate: '/eu-withdrawals/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminEuWithdrawalItemProvider::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: EU Withdrawal'], summary: 'Get a withdrawal declaration (evidence + timeline)'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: EU Withdrawal'],
+                summary: 'Get a withdrawal declaration (evidence + timeline)',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The withdrawal declaration with its full evidence timeline.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 7,
+                                    'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                    'orderId' => 12,
+                                    'orderIncrementId' => '000000012',
+                                    'customerId' => 5,
+                                    'customerName' => 'Jane Doe',
+                                    'customerEmail' => 'jane@example.com',
+                                    'isGuest' => false,
+                                    'channelId' => 1,
+                                    'channelCode' => 'default',
+                                    'locale' => 'en',
+                                    'reasonText' => 'Changed my mind.',
+                                    'status' => 'refunded',
+                                    'receivedAt' => '2026-07-20T09:00:00+00:00',
+                                    'confirmationSentAt' => '2026-07-20T09:00:05+00:00',
+                                    'finalConfirmationSentAt' => '2026-07-21T14:00:00+00:00',
+                                    'confirmationError' => null,
+                                    'declinedAt' => null,
+                                    'declinedReason' => null,
+                                    'declinedByUserId' => null,
+                                    'declinedByName' => null,
+                                    'refundedAt' => '2026-07-21T14:00:00+00:00',
+                                    'refundedByUserId' => 1,
+                                    'refundedByName' => 'Example Admin',
+                                    'refundNote' => 'Refunded via original payment method.',
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-21T14:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/eu-withdrawals/{id}/decline',
@@ -43,7 +140,49 @@ use Webkul\BagistoApi\Admin\State\AdminEuWithdrawalWriteProvider;
             input: AdminEuWithdrawalDeclineInput::class,
             provider: AdminEuWithdrawalWriteProvider::class,
             processor: AdminEuWithdrawalProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: EU Withdrawal'], summary: 'Decline a withdrawal (merchant contests entitlement)', description: 'Body `{ declined_reason }`. Sets status=declined and clears any prior refund metadata. Permission: sales.eu_withdrawals.decline.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: EU Withdrawal'],
+                summary: 'Decline a withdrawal (merchant contests entitlement)',
+                description: 'Sets status=declined and clears any prior refund metadata. Permission: sales.eu_withdrawals.decline.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['declined_reason'],
+                                'properties' => [
+                                    'declined_reason' => ['type' => 'string', 'example' => 'Item was a personalised good, exempt from withdrawal.'],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The declined withdrawal declaration.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 7,
+                                    'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                    'orderIncrementId' => '000000012',
+                                    'customerEmail' => 'jane@example.com',
+                                    'status' => 'declined',
+                                    'declinedAt' => '2026-07-21T15:00:00+00:00',
+                                    'declinedReason' => 'Item was a personalised good, exempt from withdrawal.',
+                                    'declinedByUserId' => 1,
+                                    'declinedByName' => 'Example Admin',
+                                    'refundedAt' => null,
+                                    'refundNote' => null,
+                                    'message' => 'Withdrawal declined.',
+                                    'updatedAt' => '2026-07-21T15:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/eu-withdrawals/{id}/mark-refunded',
@@ -51,7 +190,48 @@ use Webkul\BagistoApi\Admin\State\AdminEuWithdrawalWriteProvider;
             input: AdminEuWithdrawalMarkRefundedInput::class,
             provider: AdminEuWithdrawalWriteProvider::class,
             processor: AdminEuWithdrawalProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: EU Withdrawal'], summary: 'Mark a withdrawal refunded (recorded out-of-band)', description: 'Body `{ refund_note? }`. Sets status=refunded and clears any prior decline metadata. Permission: sales.eu_withdrawals.mark_refunded.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: EU Withdrawal'],
+                summary: 'Mark a withdrawal refunded (recorded out-of-band)',
+                description: 'Sets status=refunded and clears any prior decline metadata. Permission: sales.eu_withdrawals.mark_refunded.',
+                requestBody: new Model\RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'refund_note' => ['type' => 'string', 'example' => 'Refunded via original payment method.'],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The refunded withdrawal declaration.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 7,
+                                    'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                    'orderIncrementId' => '000000012',
+                                    'customerEmail' => 'jane@example.com',
+                                    'status' => 'refunded',
+                                    'declinedAt' => null,
+                                    'declinedReason' => null,
+                                    'refundedAt' => '2026-07-21T14:00:00+00:00',
+                                    'refundedByUserId' => 1,
+                                    'refundedByName' => 'Example Admin',
+                                    'refundNote' => 'Refunded via original payment method.',
+                                    'message' => 'Withdrawal marked as refunded.',
+                                    'updatedAt' => '2026-07-21T14:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/eu-withdrawals/{id}/resend-confirmation',
@@ -59,7 +239,31 @@ use Webkul\BagistoApi\Admin\State\AdminEuWithdrawalWriteProvider;
             input: AdminEuWithdrawalActionInput::class,
             provider: AdminEuWithdrawalWriteProvider::class,
             processor: AdminEuWithdrawalProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: EU Withdrawal'], summary: 'Resend the durable-medium confirmation email', description: 'Empty body. Re-sends the confirmation email in the declaration\'s locale. Permission: sales.eu_withdrawals.resend_confirmation.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: EU Withdrawal'],
+                summary: 'Resend the durable-medium confirmation email',
+                description: 'Empty body. Re-sends the confirmation email in the declaration\'s locale. Permission: sales.eu_withdrawals.resend_confirmation.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The declaration after the confirmation email was re-sent (confirmationSentAt refreshed).',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 7,
+                                    'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                    'orderIncrementId' => '000000012',
+                                    'customerEmail' => 'jane@example.com',
+                                    'status' => 'received',
+                                    'confirmationSentAt' => '2026-07-21T16:30:00+00:00',
+                                    'confirmationError' => null,
+                                    'message' => 'Confirmation email re-sent.',
+                                    'updatedAt' => '2026-07-21T16:30:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminEuWithdrawal.php
+++ b/src/Admin/Models/AdminEuWithdrawal.php
@@ -240,6 +240,15 @@ use Webkul\BagistoApi\Admin\State\AdminEuWithdrawalWriteProvider;
             provider: AdminEuWithdrawalWriteProvider::class,
             processor: AdminEuWithdrawalProcessor::class,
             openapi: new Model\Operation(
+                requestBody: new Model\RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                            'example' => new \stdClass,
+                        ],
+                    ]),
+                ),
                 tags: ['Admin Sales: EU Withdrawal'],
                 summary: 'Resend the durable-medium confirmation email',
                 description: 'Empty body. Re-sends the confirmation email in the declaration\'s locale. Permission: sales.eu_withdrawals.resend_confirmation.',

--- a/src/Admin/Models/AdminInvoice.php
+++ b/src/Admin/Models/AdminInvoice.php
@@ -247,19 +247,19 @@ use Webkul\BagistoApi\Admin\State\AdminInvoiceProvider;
         new Get(
             uriTemplate: '/invoices/export',
             provider: AdminInvoiceExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Sales: Invoices'],
-                summary: 'Export invoices as CSV',
-                description: 'Downloads the invoices datagrid as a CSV file (text/csv attachment) — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Only ?format=csv is supported.',
+                summary: 'Export invoices as csv, xls or xlsx',
+                description: 'Downloads the invoices datagrid as a csv, xls or xlsx file — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Pick the file type with ?format=csv|xls|xlsx (default csv).',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only csv.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV file downloaded (text/csv attachment).', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment.', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks the view permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminOrder.php
+++ b/src/Admin/Models/AdminOrder.php
@@ -113,19 +113,19 @@ use Webkul\BagistoApi\Admin\State\OrderCollectionProvider;
         new Get(
             uriTemplate: '/orders/export',
             provider: AdminOrderExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Sales: Orders'],
-                summary: 'Export orders as CSV',
-                description: 'Downloads the orders datagrid as a CSV file (text/csv attachment) — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Only ?format=csv is supported.',
+                summary: 'Export orders as csv, xls or xlsx',
+                description: 'Downloads the orders datagrid as a csv, xls or xlsx file — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Pick the file type with ?format=csv|xls|xlsx (default csv).',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only csv.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV file downloaded (text/csv attachment).', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment.', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks the view permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminRefund.php
+++ b/src/Admin/Models/AdminRefund.php
@@ -209,13 +209,13 @@ use Webkul\BagistoApi\Admin\State\AdminRefundProvider;
         new Get(
             uriTemplate: '/refunds/export',
             provider: AdminRefundExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Sales: Refunds'],
-                summary: 'Export refunds as CSV',
-                description: 'Downloads the refunds datagrid as a CSV file (`text/csv` attachment) — the same data the admin Refunds "Export" button produces (ID, Order ID, Refunded Amount, Billed To, Refund Date). Honours the same filters as the listing (`id`, `order_id`, `state`, `base_grand_total_from`/`_to`, `billed_to`, `created_at_from`/`_to`). The response is a binary download, not JSON. Requires `sales.refunds.view`.',
+                summary: 'Export refunds as csv, xls or xlsx',
+                description: 'Downloads the refunds datagrid as a csv, xls or xlsx file — the same data the admin Refunds "Export" button produces (ID, Order ID, Refunded Amount, Billed To, Refund Date). Honours the same filters as the listing (`id`, `order_id`, `state`, `base_grand_total_from`/`_to`, `billed_to`, `created_at_from`/`_to`). The response is a binary download, not JSON. Requires `sales.refunds.view`.',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only `csv` is supported.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: `csv`, `xls` or `xlsx`. Defaults to `csv`.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                     new Model\Parameter('id', 'query', 'Filter by refund id (integer or comma-list).', false, schema: ['type' => 'string']),
                     new Model\Parameter('order_id', 'query', 'Partial order increment_id match.', false, schema: ['type' => 'string']),
                     new Model\Parameter('state', 'query', 'Refund state.', false, schema: ['type' => 'string']),
@@ -227,16 +227,16 @@ use Webkul\BagistoApi\Admin\State\AdminRefundProvider;
                 ],
                 responses: [
                     '200' => new Model\Response(
-                        description: 'The refunds CSV file is downloaded (text/csv attachment).',
+                        description: 'The refunds export file is downloaded as an attachment.',
                         content: new \ArrayObject([
-                            'text/csv' => [
-                                'schema' => ['type' => 'string', 'format' => 'binary'],
-                            ],
+                            'text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']],
+                            'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']],
+                            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']],
                         ]),
                     ),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks sales.refunds.view.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminReportingCustomers.php
+++ b/src/Admin/Models/AdminReportingCustomers.php
@@ -69,14 +69,14 @@ use Webkul\BagistoApi\Admin\State\AdminReportingCustomersViewProvider;
             uriTemplate: '/reporting/customers/export',
             provider: AdminReportingCustomersExportProvider::class,
             paginationEnabled: false,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Reporting: Customers'],
-                summary: 'Reporting — customers export (CSV)',
-                description: 'Streams a customer stat as a CSV download (the admin Export button). REST only; send Accept: text/csv. `?type=` picks the stat group; `?format=` accepts only csv.',
+                summary: 'Reporting — customers export (csv, xls, xlsx)',
+                description: 'Streams a customer stat as a csv, xls or xlsx download (the admin Export button). REST only; send the Accept header matching the requested format. `?type=` picks the stat group; `?format=` accepts csv, xls or xlsx (default csv).',
                 parameters: [
                     new Model\Parameter('type', 'query', 'Stat group.', false, schema: ['type' => 'string']),
-                    new Model\Parameter('format', 'query', 'Export format (only csv).', false, schema: ['type' => 'string', 'enum' => ['csv'], 'example' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'example' => 'csv']),
                     new Model\Parameter('start', 'query', 'Start date.', false, schema: ['type' => 'string', 'format' => 'date']),
                     new Model\Parameter('end', 'query', 'End date.', false, schema: ['type' => 'string', 'format' => 'date']),
                     new Model\Parameter('channel', 'query', 'Channel code.', false, schema: ['type' => 'string']),

--- a/src/Admin/Models/AdminReportingProducts.php
+++ b/src/Admin/Models/AdminReportingProducts.php
@@ -70,14 +70,14 @@ use Webkul\BagistoApi\Admin\State\AdminReportingProductsViewProvider;
             uriTemplate: '/reporting/products/export',
             provider: AdminReportingProductsExportProvider::class,
             paginationEnabled: false,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Reporting: Products'],
-                summary: 'Reporting — products export (CSV)',
-                description: 'Streams a product stat as a CSV download (the admin Export button). REST only; send Accept: text/csv. `?type=` picks the stat group; `?format=` accepts only csv.',
+                summary: 'Reporting — products export (csv, xls, xlsx)',
+                description: 'Streams a product stat as a csv, xls or xlsx download (the admin Export button). REST only; send the Accept header matching the requested format. `?type=` picks the stat group; `?format=` accepts csv, xls or xlsx (default csv).',
                 parameters: [
                     new Model\Parameter('type', 'query', 'Stat group.', false, schema: ['type' => 'string']),
-                    new Model\Parameter('format', 'query', 'Export format (only csv).', false, schema: ['type' => 'string', 'enum' => ['csv'], 'example' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'example' => 'csv']),
                     new Model\Parameter('start', 'query', 'Start date.', false, schema: ['type' => 'string', 'format' => 'date']),
                     new Model\Parameter('end', 'query', 'End date.', false, schema: ['type' => 'string', 'format' => 'date']),
                     new Model\Parameter('channel', 'query', 'Channel code.', false, schema: ['type' => 'string']),

--- a/src/Admin/Models/AdminReportingSales.php
+++ b/src/Admin/Models/AdminReportingSales.php
@@ -69,14 +69,14 @@ use Webkul\BagistoApi\Admin\State\AdminReportingSalesViewProvider;
             uriTemplate: '/reporting/sales/export',
             provider: AdminReportingSalesExportProvider::class,
             paginationEnabled: false,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Reporting: Sales'],
-                summary: 'Reporting — sales export (CSV)',
-                description: 'Streams a sales stat as a CSV download (the admin Export button). REST only; send Accept: text/csv. `?type=` chooses the stat group; `?format=` accepts only csv.',
+                summary: 'Reporting — sales export (csv, xls, xlsx)',
+                description: 'Streams a sales stat as a csv, xls or xlsx download (the admin Export button). REST only; send the Accept header matching the requested format. `?type=` chooses the stat group; `?format=` accepts csv, xls or xlsx (default csv).',
                 parameters: [
                     new Model\Parameter('type', 'query', 'Stat group.', false, schema: ['type' => 'string']),
-                    new Model\Parameter('format', 'query', 'Export format (only csv).', false, schema: ['type' => 'string', 'enum' => ['csv'], 'example' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'example' => 'csv']),
                     new Model\Parameter('start', 'query', 'Start date.', false, schema: ['type' => 'string', 'format' => 'date']),
                     new Model\Parameter('end', 'query', 'End date.', false, schema: ['type' => 'string', 'format' => 'date']),
                     new Model\Parameter('channel', 'query', 'Channel code.', false, schema: ['type' => 'string']),

--- a/src/Admin/Models/AdminReturn.php
+++ b/src/Admin/Models/AdminReturn.php
@@ -32,6 +32,48 @@ use Webkul\BagistoApi\Admin\State\AdminReturnProcessor;
                 tags: ['Admin Sales: RMA'],
                 summary: 'List RMA (return) requests',
                 description: 'Admin listing of every return request (RMADataGrid parity). Filters: id, order_id, status (title), customer_name, created_at range. Sort: id (default desc), order_id, created_at.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'Paginated return requests. Detail-only fields (item/images/availableStatuses/information/messagesCount/canReopen) are null on the listing.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'data' => [
+                                        [
+                                            'id' => 12,
+                                            'orderId' => 45,
+                                            'orderIncrementId' => '000000045',
+                                            'orderStatus' => 'processing',
+                                            'customerName' => 'Jane Doe',
+                                            'customerEmail' => 'jane@example.com',
+                                            'isGuest' => 0,
+                                            'statusId' => 1,
+                                            'statusTitle' => 'Pending',
+                                            'statusColor' => '#FDB022',
+                                            'packageCondition' => null,
+                                            'information' => null,
+                                            'canReopen' => null,
+                                            'item' => null,
+                                            'images' => null,
+                                            'availableStatuses' => null,
+                                            'messagesCount' => null,
+                                            'createdAt' => '2026-07-20T10:15:30+00:00',
+                                            'updatedAt' => '2026-07-20T10:15:30+00:00',
+                                        ],
+                                    ],
+                                    'meta' => [
+                                        'currentPage' => 1,
+                                        'perPage' => 10,
+                                        'lastPage' => 1,
+                                        'total' => 1,
+                                        'from' => 1,
+                                        'to' => 1,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Get(
@@ -42,6 +84,55 @@ use Webkul\BagistoApi\Admin\State\AdminReturnProcessor;
                 tags: ['Admin Sales: RMA'],
                 summary: 'Get one RMA request',
                 description: 'Full detail of a single return request — the returned item, images, status, the customer/order context, whether it can be reopened, and the list of status transitions the admin may set next.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The return request detail. availableStatuses lists the status transitions the admin may set next.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'orderStatus' => 'processing',
+                                    'customerName' => 'Jane Doe',
+                                    'customerEmail' => 'jane@example.com',
+                                    'isGuest' => 0,
+                                    'statusId' => 1,
+                                    'statusTitle' => 'Pending',
+                                    'statusColor' => '#FDB022',
+                                    'packageCondition' => 'opened',
+                                    'information' => 'Customer reported a defect.',
+                                    'canReopen' => false,
+                                    'item' => [
+                                        'id' => 30,
+                                        'order_item_id' => 78,
+                                        'sku' => 'COASTALBREEZEMENSHOODIE',
+                                        'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                        'quantity' => 1,
+                                        'resolution' => 'return',
+                                        'reason_id' => 2,
+                                        'reason' => 'Damaged product',
+                                        'variant_id' => null,
+                                    ],
+                                    'images' => [
+                                        [
+                                            'id' => 5,
+                                            'path' => 'rma/12/damage-front.png',
+                                            'url' => 'https://example.com/storage/rma/12/damage-front.png',
+                                        ],
+                                    ],
+                                    'availableStatuses' => [
+                                        ['id' => 2, 'title' => 'Accept'],
+                                        ['id' => 3, 'title' => 'Declined'],
+                                    ],
+                                    'messagesCount' => 2,
+                                    'createdAt' => '2026-07-20T10:15:30+00:00',
+                                    'updatedAt' => '2026-07-20T10:15:30+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -72,6 +163,49 @@ use Webkul\BagistoApi\Admin\State\AdminReturnProcessor;
                         ],
                     ]),
                 ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created return request.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'orderStatus' => 'processing',
+                                    'customerName' => 'Jane Doe',
+                                    'customerEmail' => 'jane@example.com',
+                                    'isGuest' => 0,
+                                    'statusId' => 1,
+                                    'statusTitle' => 'Pending',
+                                    'statusColor' => '#FDB022',
+                                    'packageCondition' => 'opened',
+                                    'information' => 'Customer reported a defect.',
+                                    'canReopen' => false,
+                                    'item' => [
+                                        'id' => 30,
+                                        'order_item_id' => 78,
+                                        'sku' => 'COASTALBREEZEMENSHOODIE',
+                                        'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                        'quantity' => 1,
+                                        'resolution' => 'return',
+                                        'reason_id' => 2,
+                                        'reason' => 'Damaged product',
+                                        'variant_id' => null,
+                                    ],
+                                    'images' => [],
+                                    'availableStatuses' => [
+                                        ['id' => 2, 'title' => 'Accept'],
+                                        ['id' => 3, 'title' => 'Declined'],
+                                    ],
+                                    'messagesCount' => 0,
+                                    'createdAt' => '2026-07-20T10:15:30+00:00',
+                                    'updatedAt' => '2026-07-20T10:15:30+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -97,6 +231,30 @@ use Webkul\BagistoApi\Admin\State\AdminReturnProcessor;
                         ],
                     ]),
                 ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated return request after the status change.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 2,
+                                    'statusTitle' => 'Accept',
+                                    'statusColor' => '#12B76A',
+                                    'canReopen' => false,
+                                    'availableStatuses' => [
+                                        ['id' => 5, 'title' => 'Received package'],
+                                        ['id' => 4, 'title' => 'Dispatched package'],
+                                    ],
+                                    'messagesCount' => 3,
+                                    'updatedAt' => '2026-07-20T11:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -107,6 +265,30 @@ use Webkul\BagistoApi\Admin\State\AdminReturnProcessor;
                 tags: ['Admin Sales: RMA'],
                 summary: 'Reopen an RMA request',
                 description: 'Reopens a declined/canceled RMA back to pending when store settings allow it (otherwise 422). Empty body. Returns the updated RMA. Permission: sales.rma.requests.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The reopened return request.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 1,
+                                    'statusTitle' => 'Pending',
+                                    'statusColor' => '#FDB022',
+                                    'canReopen' => false,
+                                    'availableStatuses' => [
+                                        ['id' => 2, 'title' => 'Accept'],
+                                        ['id' => 3, 'title' => 'Declined'],
+                                    ],
+                                    'messagesCount' => 3,
+                                    'updatedAt' => '2026-07-20T11:20:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Admin/Models/AdminReturn.php
+++ b/src/Admin/Models/AdminReturn.php
@@ -262,6 +262,15 @@ use Webkul\BagistoApi\Admin\State\AdminReturnProcessor;
             processor: AdminReturnProcessor::class,
             read: false,
             openapi: new Model\Operation(
+                requestBody: new Model\RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                            'example' => new \stdClass,
+                        ],
+                    ]),
+                ),
                 tags: ['Admin Sales: RMA'],
                 summary: 'Reopen an RMA request',
                 description: 'Reopens a declined/canceled RMA back to pending when store settings allow it (otherwise 422). Empty body. Returns the updated RMA. Permission: sales.rma.requests.',

--- a/src/Admin/Models/AdminReturnMessage.php
+++ b/src/Admin/Models/AdminReturnMessage.php
@@ -31,6 +31,35 @@ use Webkul\BagistoApi\Contracts\SnakeCaseFieldsResource;
                 parameters: [
                     new Model\Parameter('return_id', 'query', 'Return (RMA) id', true, schema: ['type' => 'integer']),
                 ],
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA conversation messages, newest first.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    [
+                                        'id' => 90,
+                                        'rmaId' => 12,
+                                        'message' => 'We have received your package.',
+                                        'isAdmin' => true,
+                                        'attachment' => null,
+                                        'attachmentUrl' => null,
+                                        'createdAt' => '2026-07-20T11:30:00+00:00',
+                                    ],
+                                    [
+                                        'id' => 87,
+                                        'rmaId' => 12,
+                                        'message' => 'The hoodie zipper is broken.',
+                                        'isAdmin' => false,
+                                        'attachment' => 'rma/12/messages/zipper.jpg',
+                                        'attachmentUrl' => 'https://example.com/storage/rma/12/messages/zipper.jpg',
+                                        'createdAt' => '2026-07-20T10:20:00+00:00',
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -55,6 +84,24 @@ use Webkul\BagistoApi\Contracts\SnakeCaseFieldsResource;
                         ],
                     ]),
                 ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created admin message.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 91,
+                                    'rmaId' => 12,
+                                    'message' => 'We have received your package.',
+                                    'isAdmin' => true,
+                                    'attachment' => null,
+                                    'attachmentUrl' => null,
+                                    'createdAt' => '2026-07-20T11:35:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Admin/Models/AdminReturnReason.php
+++ b/src/Admin/Models/AdminReturnReason.php
@@ -25,6 +25,19 @@ use Webkul\BagistoApi\Admin\State\AdminReturnReasonProvider;
                 parameters: [
                     new Model\Parameter('resolution_type', 'query', 'return | cancel_items', true, schema: ['type' => 'string', 'enum' => ['return', 'cancel_items']]),
                 ],
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'Active reasons for the resolution type.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    ['id' => 2, 'title' => 'Damaged product', 'position' => 1],
+                                    ['id' => 3, 'title' => 'Wrong item delivered', 'position' => 2],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Admin/Models/AdminReturnableItem.php
+++ b/src/Admin/Models/AdminReturnableItem.php
@@ -25,6 +25,31 @@ use Webkul\BagistoApi\Admin\State\AdminReturnableItemProvider;
                 parameters: [
                     new Model\Parameter('order_id', 'query', 'Order id', true, schema: ['type' => 'integer']),
                 ],
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The returnable items of the order, with server-enforced quantity caps.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    [
+                                        'orderItemId' => 78,
+                                        'productId' => 1,
+                                        'sku' => 'COASTALBREEZEMENSHOODIE',
+                                        'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                        'type' => 'simple',
+                                        'price' => 100,
+                                        'qtyOrdered' => 2,
+                                        'currentQuantity' => 2,
+                                        'forReturnQuantity' => 2,
+                                        'forCancelQuantity' => 0,
+                                        'rmaQuantity' => 0,
+                                        'rmaReturnPeriod' => 30,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Admin/Models/AdminRmaCustomField.php
+++ b/src/Admin/Models/AdminRmaCustomField.php
@@ -30,19 +30,155 @@ use Webkul\BagistoApi\Admin\State\AdminRmaCustomFieldWriteProvider;
             uriTemplate: '/rma/custom-fields',
             provider: AdminRmaCustomFieldCollectionProvider::class,
             paginationEnabled: false,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'List RMA custom fields', description: 'Extra fields the return form collects. Filters: code (LIKE), label (LIKE), type, status. Sort: id (default desc), position, code.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'List RMA custom fields',
+                description: 'Extra fields the return form collects. Filters: code (LIKE), label (LIKE), type, status. Sort: id (default desc), position, code.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA custom fields. options is populated only for select/multiselect/checkbox/radio types.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'data' => [
+                                        [
+                                            'id' => 4,
+                                            'code' => 'preferred_resolution',
+                                            'label' => 'Preferred resolution',
+                                            'type' => 'select',
+                                            'isRequired' => 1,
+                                            'position' => 1,
+                                            'inputValidation' => null,
+                                            'status' => 1,
+                                            'options' => [
+                                                ['id' => 11, 'name' => 'Refund', 'value' => 'refund'],
+                                                ['id' => 12, 'name' => 'Replacement', 'value' => 'replacement'],
+                                            ],
+                                            'message' => null,
+                                            'createdAt' => '2026-07-20T09:00:00+00:00',
+                                            'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                        ],
+                                    ],
+                                    'meta' => [
+                                        'currentPage' => 1,
+                                        'perPage' => 10,
+                                        'lastPage' => 1,
+                                        'total' => 1,
+                                        'from' => 1,
+                                        'to' => 1,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Get(
             uriTemplate: '/rma/custom-fields/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaCustomFieldItemProvider::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Get an RMA custom field (with its options)'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Get an RMA custom field (with its options)',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA custom field with its options.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 4,
+                                    'code' => 'preferred_resolution',
+                                    'label' => 'Preferred resolution',
+                                    'type' => 'select',
+                                    'isRequired' => 1,
+                                    'position' => 1,
+                                    'inputValidation' => null,
+                                    'status' => 1,
+                                    'options' => [
+                                        ['id' => 11, 'name' => 'Refund', 'value' => 'refund'],
+                                        ['id' => 12, 'name' => 'Replacement', 'value' => 'replacement'],
+                                    ],
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/rma/custom-fields',
             input: AdminRmaCustomFieldCreateInput::class,
             processor: AdminRmaCustomFieldProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Create an RMA custom field', description: 'Body `{ code, label, position, type, is_required, input_validation, status, options: [{ name, value }] }`. `options` required for select/multiselect/checkbox/radio. Permission: sales.rma.custom-fields.create.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Create an RMA custom field',
+                description: '`options` is required for select/multiselect/checkbox/radio types. Permission: sales.rma.custom-fields.create.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['code', 'label', 'type'],
+                                'properties' => [
+                                    'code' => ['type' => 'string', 'example' => 'preferred_resolution'],
+                                    'label' => ['type' => 'string', 'example' => 'Preferred resolution'],
+                                    'type' => ['type' => 'string', 'enum' => ['text', 'textarea', 'select', 'multiselect', 'checkbox', 'radio'], 'example' => 'select'],
+                                    'is_required' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'position' => ['type' => 'integer', 'example' => 1],
+                                    'input_validation' => ['type' => 'string', 'example' => null],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'options' => [
+                                        'type' => 'array',
+                                        'description' => 'Required for select/multiselect/checkbox/radio.',
+                                        'items' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'name' => ['type' => 'string'],
+                                                'value' => ['type' => 'string'],
+                                            ],
+                                        ],
+                                        'example' => [
+                                            ['name' => 'Refund', 'value' => 'refund'],
+                                            ['name' => 'Replacement', 'value' => 'replacement'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created RMA custom field.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 4,
+                                    'code' => 'preferred_resolution',
+                                    'label' => 'Preferred resolution',
+                                    'type' => 'select',
+                                    'isRequired' => 1,
+                                    'position' => 1,
+                                    'inputValidation' => null,
+                                    'status' => 1,
+                                    'options' => [
+                                        ['id' => 11, 'name' => 'Refund', 'value' => 'refund'],
+                                        ['id' => 12, 'name' => 'Replacement', 'value' => 'replacement'],
+                                    ],
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Put(
             uriTemplate: '/rma/custom-fields/{id}',
@@ -50,14 +186,88 @@ use Webkul\BagistoApi\Admin\State\AdminRmaCustomFieldWriteProvider;
             input: AdminRmaCustomFieldUpdateInput::class,
             provider: AdminRmaCustomFieldWriteProvider::class,
             processor: AdminRmaCustomFieldProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Update an RMA custom field', description: 'Permission: sales.rma.custom-fields.edit.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Update an RMA custom field',
+                description: 'Partial update. Sending `options` replaces the full option set. Permission: sales.rma.custom-fields.edit.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'label' => ['type' => 'string', 'example' => 'How should we resolve this?'],
+                                    'is_required' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 0],
+                                    'position' => ['type' => 'integer', 'example' => 2],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'options' => [
+                                        'type' => 'array',
+                                        'items' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'name' => ['type' => 'string'],
+                                                'value' => ['type' => 'string'],
+                                            ],
+                                        ],
+                                        'example' => [
+                                            ['name' => 'Refund', 'value' => 'refund'],
+                                            ['name' => 'Store credit', 'value' => 'store_credit'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated RMA custom field.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 4,
+                                    'code' => 'preferred_resolution',
+                                    'label' => 'How should we resolve this?',
+                                    'type' => 'select',
+                                    'isRequired' => 0,
+                                    'position' => 2,
+                                    'inputValidation' => null,
+                                    'status' => 1,
+                                    'options' => [
+                                        ['id' => 13, 'name' => 'Refund', 'value' => 'refund'],
+                                        ['id' => 14, 'name' => 'Store credit', 'value' => 'store_credit'],
+                                    ],
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T11:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Delete(
             uriTemplate: '/rma/custom-fields/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaCustomFieldWriteProvider::class,
             processor: AdminRmaCustomFieldProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Delete an RMA custom field', description: 'Permission: sales.rma.custom-fields.delete.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Delete an RMA custom field',
+                description: 'Permission: sales.rma.custom-fields.delete.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA custom field was deleted.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['message' => 'RMA custom field deleted successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminRmaCustomFieldMassDelete.php
+++ b/src/Admin/Models/AdminRmaCustomFieldMassDelete.php
@@ -16,7 +16,35 @@ use Webkul\BagistoApi\Admin\State\AdminRmaCustomFieldMassDeleteProcessor;
     shortName: 'AdminRmaCustomFieldMassDelete',
     normalizationContext: ['skip_null_values' => false],
     operations: [
-        new Post(uriTemplate: '/rma/custom-fields/mass-delete', input: AdminRmaCustomFieldMassDeleteInput::class, processor: AdminRmaCustomFieldMassDeleteProcessor::class, openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-delete RMA custom fields', description: 'Body `{ indices: int[] }`. Permission: sales.rma.custom-fields.delete.')),
+        new Post(uriTemplate: '/rma/custom-fields/mass-delete', input: AdminRmaCustomFieldMassDeleteInput::class, processor: AdminRmaCustomFieldMassDeleteProcessor::class, openapi: new Model\Operation(
+            tags: ['Admin Sales: RMA'],
+            summary: 'Mass-delete RMA custom fields',
+            description: 'Permission: sales.rma.custom-fields.delete.',
+            requestBody: new Model\RequestBody(
+                required: true,
+                content: new \ArrayObject([
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'required' => ['indices'],
+                            'properties' => [
+                                'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [4, 6]],
+                            ],
+                        ],
+                    ],
+                ]),
+            ),
+            responses: [
+                '200' => new Model\Response(
+                    description: 'The deleted custom-field ids.',
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'example' => ['deleted' => [4, 6], 'message' => 'Selected RMA custom fields deleted successfully.'],
+                        ],
+                    ]),
+                ),
+            ],
+        )),
     ],
     graphQlOperations: [
         new Mutation(name: 'create', input: AdminRmaCustomFieldMassDeleteInput::class, processor: AdminRmaCustomFieldMassDeleteProcessor::class),

--- a/src/Admin/Models/AdminRmaCustomFieldMassUpdateStatus.php
+++ b/src/Admin/Models/AdminRmaCustomFieldMassUpdateStatus.php
@@ -16,7 +16,36 @@ use Webkul\BagistoApi\Admin\State\AdminRmaCustomFieldMassUpdateStatusProcessor;
     shortName: 'AdminRmaCustomFieldMassUpdateStatus',
     normalizationContext: ['skip_null_values' => false],
     operations: [
-        new Post(uriTemplate: '/rma/custom-fields/mass-update-status', input: AdminRmaCustomFieldMassUpdateStatusInput::class, processor: AdminRmaCustomFieldMassUpdateStatusProcessor::class, openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-update RMA custom field status', description: 'Body `{ indices: int[], value: 0|1 }`. Permission: sales.rma.custom-fields.edit.')),
+        new Post(uriTemplate: '/rma/custom-fields/mass-update-status', input: AdminRmaCustomFieldMassUpdateStatusInput::class, processor: AdminRmaCustomFieldMassUpdateStatusProcessor::class, openapi: new Model\Operation(
+            tags: ['Admin Sales: RMA'],
+            summary: 'Mass-update RMA custom field status',
+            description: 'Permission: sales.rma.custom-fields.edit.',
+            requestBody: new Model\RequestBody(
+                required: true,
+                content: new \ArrayObject([
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'required' => ['indices', 'value'],
+                            'properties' => [
+                                'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [4, 6]],
+                                'value' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                            ],
+                        ],
+                    ],
+                ]),
+            ),
+            responses: [
+                '200' => new Model\Response(
+                    description: 'The updated custom-field ids.',
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'example' => ['updated' => [4, 6], 'message' => 'Selected RMA custom fields updated successfully.'],
+                        ],
+                    ]),
+                ),
+            ],
+        )),
     ],
     graphQlOperations: [
         new Mutation(name: 'create', input: AdminRmaCustomFieldMassUpdateStatusInput::class, processor: AdminRmaCustomFieldMassUpdateStatusProcessor::class),

--- a/src/Admin/Models/AdminRmaReason.php
+++ b/src/Admin/Models/AdminRmaReason.php
@@ -30,19 +30,123 @@ use Webkul\BagistoApi\Admin\State\AdminRmaReasonWriteProvider;
             uriTemplate: '/rma/reasons',
             provider: AdminRmaReasonCollectionProvider::class,
             paginationEnabled: false,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'List RMA reasons', description: 'Return/cancel reasons the RMA form offers. Filters: title (LIKE), status. Sort: id (default desc), position, title.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'List RMA reasons',
+                description: 'Return/cancel reasons the RMA form offers. Filters: title (LIKE), status. Sort: id (default desc), position, title.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA reasons.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'data' => [
+                                        [
+                                            'id' => 2,
+                                            'title' => 'Damaged product',
+                                            'status' => 1,
+                                            'position' => 1,
+                                            'isAdmin' => 0,
+                                            'resolutionType' => ['return', 'cancel_items'],
+                                            'message' => null,
+                                            'createdAt' => '2026-07-20T09:00:00+00:00',
+                                            'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                        ],
+                                    ],
+                                    'meta' => [
+                                        'currentPage' => 1,
+                                        'perPage' => 10,
+                                        'lastPage' => 1,
+                                        'total' => 1,
+                                        'from' => 1,
+                                        'to' => 1,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Get(
             uriTemplate: '/rma/reasons/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaReasonItemProvider::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Get an RMA reason'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Get an RMA reason',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA reason.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 2,
+                                    'title' => 'Damaged product',
+                                    'status' => 1,
+                                    'position' => 1,
+                                    'isAdmin' => 0,
+                                    'resolutionType' => ['return', 'cancel_items'],
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/rma/reasons',
             input: AdminRmaReasonCreateInput::class,
             processor: AdminRmaReasonProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Create an RMA reason', description: 'Body `{ title, status, position, resolution_type: ["return","cancel_items"] }`. Permission: sales.rma.reasons.create.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Create an RMA reason',
+                description: 'Permission: sales.rma.reasons.create.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['title', 'resolution_type'],
+                                'properties' => [
+                                    'title' => ['type' => 'string', 'example' => 'Damaged product'],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'position' => ['type' => 'integer', 'example' => 1],
+                                    'resolution_type' => [
+                                        'type' => 'array',
+                                        'items' => ['type' => 'string', 'enum' => ['return', 'cancel_items']],
+                                        'example' => ['return', 'cancel_items'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created RMA reason.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 6,
+                                    'title' => 'Damaged product',
+                                    'status' => 1,
+                                    'position' => 1,
+                                    'isAdmin' => 0,
+                                    'resolutionType' => ['return', 'cancel_items'],
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Put(
             uriTemplate: '/rma/reasons/{id}',
@@ -50,14 +154,72 @@ use Webkul\BagistoApi\Admin\State\AdminRmaReasonWriteProvider;
             input: AdminRmaReasonUpdateInput::class,
             provider: AdminRmaReasonWriteProvider::class,
             processor: AdminRmaReasonProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Update an RMA reason', description: 'Permission: sales.rma.reasons.edit.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Update an RMA reason',
+                description: 'Partial update. Permission: sales.rma.reasons.edit.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'title' => ['type' => 'string', 'example' => 'Damaged on arrival'],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'position' => ['type' => 'integer', 'example' => 2],
+                                    'resolution_type' => [
+                                        'type' => 'array',
+                                        'items' => ['type' => 'string', 'enum' => ['return', 'cancel_items']],
+                                        'example' => ['return'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated RMA reason.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 2,
+                                    'title' => 'Damaged on arrival',
+                                    'status' => 1,
+                                    'position' => 2,
+                                    'isAdmin' => 0,
+                                    'resolutionType' => ['return'],
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T11:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Delete(
             uriTemplate: '/rma/reasons/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaReasonWriteProvider::class,
             processor: AdminRmaReasonProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Delete an RMA reason', description: 'Permission: sales.rma.reasons.delete.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Delete an RMA reason',
+                description: 'Permission: sales.rma.reasons.delete.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA reason was deleted.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['message' => 'RMA reason deleted successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [
@@ -97,6 +259,8 @@ class AdminRmaReason
     /** @var array<int,string>|null */
     #[ApiProperty(openapiContext: ['type' => 'array'])]
     public ?array $resolution_type = null;
+
+    public ?string $message = null;
 
     public ?string $created_at = null;
 

--- a/src/Admin/Models/AdminRmaReasonMassDelete.php
+++ b/src/Admin/Models/AdminRmaReasonMassDelete.php
@@ -20,7 +20,35 @@ use Webkul\BagistoApi\Admin\State\AdminRmaReasonMassDeleteProcessor;
             uriTemplate: '/rma/reasons/mass-delete',
             input: AdminRmaReasonMassDeleteInput::class,
             processor: AdminRmaReasonMassDeleteProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-delete RMA reasons', description: 'Body `{ indices: int[] }`. Permission: sales.rma.reasons.delete.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Mass-delete RMA reasons',
+                description: 'Permission: sales.rma.reasons.delete.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['indices'],
+                                'properties' => [
+                                    'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [2, 3, 4]],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The deleted reason ids.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['deleted' => [2, 3, 4], 'message' => 'Selected RMA reasons deleted successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminRmaReasonMassUpdateStatus.php
+++ b/src/Admin/Models/AdminRmaReasonMassUpdateStatus.php
@@ -20,7 +20,36 @@ use Webkul\BagistoApi\Admin\State\AdminRmaReasonMassUpdateStatusProcessor;
             uriTemplate: '/rma/reasons/mass-update-status',
             input: AdminRmaReasonMassUpdateStatusInput::class,
             processor: AdminRmaReasonMassUpdateStatusProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-update RMA reason status', description: 'Body `{ indices: int[], value: 0|1 }`. Permission: sales.rma.reasons.edit.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Mass-update RMA reason status',
+                description: 'Permission: sales.rma.reasons.edit.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['indices', 'value'],
+                                'properties' => [
+                                    'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [2, 3]],
+                                    'value' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated reason ids.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['updated' => [2, 3], 'message' => 'Selected RMA reasons updated successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminRmaRule.php
+++ b/src/Admin/Models/AdminRmaRule.php
@@ -30,19 +30,119 @@ use Webkul\BagistoApi\Admin\State\AdminRmaRuleWriteProvider;
             uriTemplate: '/rma/rules',
             provider: AdminRmaRuleCollectionProvider::class,
             paginationEnabled: false,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'List RMA rules', description: 'Return rules (a rule sets the return window for matching products). Filters: name (LIKE), status. Sort: id (default desc), name.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'List RMA rules',
+                description: 'Return rules (a rule sets the return window for matching products). Filters: name (LIKE), status. Sort: id (default desc), name.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA rules.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'data' => [
+                                        [
+                                            'id' => 3,
+                                            'name' => 'Apparel 30-day returns',
+                                            'description' => 'Return window for all clothing.',
+                                            'status' => 1,
+                                            'returnPeriod' => 30,
+                                            'default' => 0,
+                                            'message' => null,
+                                            'createdAt' => '2026-07-20T09:00:00+00:00',
+                                            'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                        ],
+                                    ],
+                                    'meta' => [
+                                        'currentPage' => 1,
+                                        'perPage' => 10,
+                                        'lastPage' => 1,
+                                        'total' => 1,
+                                        'from' => 1,
+                                        'to' => 1,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Get(
             uriTemplate: '/rma/rules/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaRuleItemProvider::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Get an RMA rule'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Get an RMA rule',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA rule.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 3,
+                                    'name' => 'Apparel 30-day returns',
+                                    'description' => 'Return window for all clothing.',
+                                    'status' => 1,
+                                    'returnPeriod' => 30,
+                                    'default' => 0,
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/rma/rules',
             input: AdminRmaRuleCreateInput::class,
             processor: AdminRmaRuleProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Create an RMA rule', description: 'Body `{ name, description, status, return_period }`. Permission: sales.rma.rules.create.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Create an RMA rule',
+                description: 'Permission: sales.rma.rules.create.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['name', 'return_period'],
+                                'properties' => [
+                                    'name' => ['type' => 'string', 'example' => 'Apparel 30-day returns'],
+                                    'description' => ['type' => 'string', 'example' => 'Return window for all clothing.'],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'return_period' => ['type' => 'integer', 'example' => 30],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created RMA rule.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 3,
+                                    'name' => 'Apparel 30-day returns',
+                                    'description' => 'Return window for all clothing.',
+                                    'status' => 1,
+                                    'returnPeriod' => 30,
+                                    'default' => 0,
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Put(
             uriTemplate: '/rma/rules/{id}',
@@ -50,14 +150,68 @@ use Webkul\BagistoApi\Admin\State\AdminRmaRuleWriteProvider;
             input: AdminRmaRuleUpdateInput::class,
             provider: AdminRmaRuleWriteProvider::class,
             processor: AdminRmaRuleProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Update an RMA rule', description: 'Permission: sales.rma.rules.edit.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Update an RMA rule',
+                description: 'Partial update. Permission: sales.rma.rules.edit.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'name' => ['type' => 'string', 'example' => 'Apparel 45-day returns'],
+                                    'description' => ['type' => 'string', 'example' => 'Extended window for clothing.'],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'return_period' => ['type' => 'integer', 'example' => 45],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated RMA rule.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 3,
+                                    'name' => 'Apparel 45-day returns',
+                                    'description' => 'Extended window for clothing.',
+                                    'status' => 1,
+                                    'returnPeriod' => 45,
+                                    'default' => 0,
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T11:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Delete(
             uriTemplate: '/rma/rules/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaRuleWriteProvider::class,
             processor: AdminRmaRuleProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Delete an RMA rule', description: 'Permission: sales.rma.rules.delete.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Delete an RMA rule',
+                description: 'Permission: sales.rma.rules.delete.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA rule was deleted.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['message' => 'RMA rule deleted successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminRmaRuleMassDelete.php
+++ b/src/Admin/Models/AdminRmaRuleMassDelete.php
@@ -16,7 +16,35 @@ use Webkul\BagistoApi\Admin\State\AdminRmaRuleMassDeleteProcessor;
     shortName: 'AdminRmaRuleMassDelete',
     normalizationContext: ['skip_null_values' => false],
     operations: [
-        new Post(uriTemplate: '/rma/rules/mass-delete', input: AdminRmaRuleMassDeleteInput::class, processor: AdminRmaRuleMassDeleteProcessor::class, openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-delete RMA rules', description: 'Body `{ indices: int[] }`. Permission: sales.rma.rules.delete.')),
+        new Post(uriTemplate: '/rma/rules/mass-delete', input: AdminRmaRuleMassDeleteInput::class, processor: AdminRmaRuleMassDeleteProcessor::class, openapi: new Model\Operation(
+            tags: ['Admin Sales: RMA'],
+            summary: 'Mass-delete RMA rules',
+            description: 'Permission: sales.rma.rules.delete.',
+            requestBody: new Model\RequestBody(
+                required: true,
+                content: new \ArrayObject([
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'required' => ['indices'],
+                            'properties' => [
+                                'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [3, 5]],
+                            ],
+                        ],
+                    ],
+                ]),
+            ),
+            responses: [
+                '200' => new Model\Response(
+                    description: 'The deleted rule ids.',
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'example' => ['deleted' => [3, 5], 'message' => 'Selected RMA rules deleted successfully.'],
+                        ],
+                    ]),
+                ),
+            ],
+        )),
     ],
     graphQlOperations: [
         new Mutation(name: 'create', input: AdminRmaRuleMassDeleteInput::class, processor: AdminRmaRuleMassDeleteProcessor::class),

--- a/src/Admin/Models/AdminRmaRuleMassUpdateStatus.php
+++ b/src/Admin/Models/AdminRmaRuleMassUpdateStatus.php
@@ -16,7 +16,36 @@ use Webkul\BagistoApi\Admin\State\AdminRmaRuleMassUpdateStatusProcessor;
     shortName: 'AdminRmaRuleMassUpdateStatus',
     normalizationContext: ['skip_null_values' => false],
     operations: [
-        new Post(uriTemplate: '/rma/rules/mass-update-status', input: AdminRmaRuleMassUpdateStatusInput::class, processor: AdminRmaRuleMassUpdateStatusProcessor::class, openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-update RMA rule status', description: 'Body `{ indices: int[], value: 0|1 }`. Permission: sales.rma.rules.edit.')),
+        new Post(uriTemplate: '/rma/rules/mass-update-status', input: AdminRmaRuleMassUpdateStatusInput::class, processor: AdminRmaRuleMassUpdateStatusProcessor::class, openapi: new Model\Operation(
+            tags: ['Admin Sales: RMA'],
+            summary: 'Mass-update RMA rule status',
+            description: 'Permission: sales.rma.rules.edit.',
+            requestBody: new Model\RequestBody(
+                required: true,
+                content: new \ArrayObject([
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'required' => ['indices', 'value'],
+                            'properties' => [
+                                'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [3, 5]],
+                                'value' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                            ],
+                        ],
+                    ],
+                ]),
+            ),
+            responses: [
+                '200' => new Model\Response(
+                    description: 'The updated rule ids.',
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'example' => ['updated' => [3, 5], 'message' => 'Selected RMA rules updated successfully.'],
+                        ],
+                    ]),
+                ),
+            ],
+        )),
     ],
     graphQlOperations: [
         new Mutation(name: 'create', input: AdminRmaRuleMassUpdateStatusInput::class, processor: AdminRmaRuleMassUpdateStatusProcessor::class),

--- a/src/Admin/Models/AdminRmaStatus.php
+++ b/src/Admin/Models/AdminRmaStatus.php
@@ -30,19 +30,115 @@ use Webkul\BagistoApi\Admin\State\AdminRmaStatusWriteProvider;
             uriTemplate: '/rma/statuses',
             provider: AdminRmaStatusCollectionProvider::class,
             paginationEnabled: false,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'List RMA statuses', description: 'Custom return statuses. Filters: title (LIKE), status. Sort: id (default desc), title. Default statuses cannot be deleted.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'List RMA statuses',
+                description: 'Custom return statuses. Filters: title (LIKE), status. Sort: id (default desc), title. Default statuses cannot be deleted.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA statuses.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'data' => [
+                                        [
+                                            'id' => 9,
+                                            'title' => 'Awaiting inspection',
+                                            'status' => 1,
+                                            'color' => '#FDB022',
+                                            'default' => 0,
+                                            'message' => null,
+                                            'createdAt' => '2026-07-20T09:00:00+00:00',
+                                            'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                        ],
+                                    ],
+                                    'meta' => [
+                                        'currentPage' => 1,
+                                        'perPage' => 10,
+                                        'lastPage' => 1,
+                                        'total' => 1,
+                                        'from' => 1,
+                                        'to' => 1,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Get(
             uriTemplate: '/rma/statuses/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaStatusItemProvider::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Get an RMA status'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Get an RMA status',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA status.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 9,
+                                    'title' => 'Awaiting inspection',
+                                    'status' => 1,
+                                    'color' => '#FDB022',
+                                    'default' => 0,
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Post(
             uriTemplate: '/rma/statuses',
             input: AdminRmaStatusCreateInput::class,
             processor: AdminRmaStatusProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Create an RMA status', description: 'Body `{ title, status, color }`. Title must be unique. Permission: sales.rma.statuses.create.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Create an RMA status',
+                description: 'Title must be unique. Permission: sales.rma.statuses.create.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['title'],
+                                'properties' => [
+                                    'title' => ['type' => 'string', 'example' => 'Awaiting inspection'],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'color' => ['type' => 'string', 'example' => '#FDB022'],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created RMA status.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 9,
+                                    'title' => 'Awaiting inspection',
+                                    'status' => 1,
+                                    'color' => '#FDB022',
+                                    'default' => 0,
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Put(
             uriTemplate: '/rma/statuses/{id}',
@@ -50,14 +146,66 @@ use Webkul\BagistoApi\Admin\State\AdminRmaStatusWriteProvider;
             input: AdminRmaStatusUpdateInput::class,
             provider: AdminRmaStatusWriteProvider::class,
             processor: AdminRmaStatusProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Update an RMA status', description: 'Permission: sales.rma.statuses.edit.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Update an RMA status',
+                description: 'Partial update. Permission: sales.rma.statuses.edit.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'title' => ['type' => 'string', 'example' => 'Inspection complete'],
+                                    'status' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                    'color' => ['type' => 'string', 'example' => '#12B76A'],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated RMA status.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 9,
+                                    'title' => 'Inspection complete',
+                                    'status' => 1,
+                                    'color' => '#12B76A',
+                                    'default' => 0,
+                                    'message' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T11:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
         new Delete(
             uriTemplate: '/rma/statuses/{id}',
             requirements: ['id' => '\d+'],
             provider: AdminRmaStatusWriteProvider::class,
             processor: AdminRmaStatusProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Delete an RMA status', description: 'Only non-default statuses can be deleted (422 otherwise). Permission: sales.rma.statuses.delete.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Delete an RMA status',
+                description: 'Only non-default statuses can be deleted (422 otherwise). Permission: sales.rma.statuses.delete.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The RMA status was deleted.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['message' => 'RMA status deleted successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminRmaStatusMassDelete.php
+++ b/src/Admin/Models/AdminRmaStatusMassDelete.php
@@ -20,7 +20,35 @@ use Webkul\BagistoApi\Admin\State\AdminRmaStatusMassDeleteProcessor;
             uriTemplate: '/rma/statuses/mass-delete',
             input: AdminRmaStatusMassDeleteInput::class,
             processor: AdminRmaStatusMassDeleteProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-delete RMA statuses', description: 'Body `{ indices: int[] }`. Default statuses are skipped. Permission: sales.rma.statuses.delete.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Mass-delete RMA statuses',
+                description: 'Default statuses are skipped. Permission: sales.rma.statuses.delete.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['indices'],
+                                'properties' => [
+                                    'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [9, 10]],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The deleted status ids (default statuses skipped).',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['deleted' => [9, 10], 'message' => 'Selected RMA statuses deleted successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminRmaStatusMassUpdateStatus.php
+++ b/src/Admin/Models/AdminRmaStatusMassUpdateStatus.php
@@ -20,7 +20,36 @@ use Webkul\BagistoApi\Admin\State\AdminRmaStatusMassUpdateStatusProcessor;
             uriTemplate: '/rma/statuses/mass-update-status',
             input: AdminRmaStatusMassUpdateStatusInput::class,
             processor: AdminRmaStatusMassUpdateStatusProcessor::class,
-            openapi: new Model\Operation(tags: ['Admin Sales: RMA'], summary: 'Mass-update RMA status active flag', description: 'Body `{ indices: int[], value: 0|1 }`. Permission: sales.rma.statuses.edit.'),
+            openapi: new Model\Operation(
+                tags: ['Admin Sales: RMA'],
+                summary: 'Mass-update RMA status active flag',
+                description: 'Permission: sales.rma.statuses.edit.',
+                requestBody: new Model\RequestBody(
+                    required: true,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['indices', 'value'],
+                                'properties' => [
+                                    'indices' => ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [9, 10]],
+                                    'value' => ['type' => 'integer', 'enum' => [0, 1], 'example' => 1],
+                                ],
+                            ],
+                        ],
+                    ]),
+                ),
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The updated status ids.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => ['updated' => [9, 10], 'message' => 'Selected RMA statuses updated successfully.'],
+                            ],
+                        ]),
+                    ),
+                ],
+            ),
         ),
     ],
     graphQlOperations: [

--- a/src/Admin/Models/AdminSettingsTaxRate.php
+++ b/src/Admin/Models/AdminSettingsTaxRate.php
@@ -192,14 +192,14 @@ use Webkul\BagistoApi\Admin\State\AdminSettingsTaxRateWriteProvider;
         new Get(
             uriTemplate: '/settings/tax-rates/export',
             provider: AdminSettingsTaxRateExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             paginationEnabled: false,
             openapi: new Model\Operation(
                 tags: ['Admin Settings: Tax Rates'],
-                summary: 'Export tax rates as CSV',
-                description: 'Streams the tax-rate datagrid as a CSV download (the admin Export button). Honours the same filters as the listing. REST only; send Accept: text/csv.',
+                summary: 'Export tax rates as csv, xls or xlsx',
+                description: 'Streams the tax-rate datagrid as a csv, xls or xlsx download (the admin Export button). Honours the same filters as the listing. REST only; send the Accept header matching the requested format.',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Only "csv" is supported.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'example' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'example' => 'csv']),
                     new Model\Parameter('identifier', 'query', 'Partial match on identifier.', false, schema: ['type' => 'string']),
                     new Model\Parameter('country', 'query', 'Country code exact.', false, schema: ['type' => 'string']),
                     new Model\Parameter('state', 'query', 'State exact.', false, schema: ['type' => 'string']),
@@ -207,8 +207,8 @@ use Webkul\BagistoApi\Admin\State\AdminSettingsTaxRateWriteProvider;
                     new Model\Parameter('tax_rate_to', 'query', 'Maximum tax rate (inclusive).', false, schema: ['type' => 'number']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV attachment (tax-rates.csv).'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment (tax-rates.csv, .xls or .xlsx).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminShipment.php
+++ b/src/Admin/Models/AdminShipment.php
@@ -116,19 +116,19 @@ use Webkul\BagistoApi\Admin\State\AdminShipmentProvider;
         new Get(
             uriTemplate: '/shipments/export',
             provider: AdminShipmentExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Sales: Shipments'],
-                summary: 'Export shipments as CSV',
-                description: 'Downloads the shipments datagrid as a CSV file (text/csv attachment) — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Only ?format=csv is supported.',
+                summary: 'Export shipments as csv, xls or xlsx',
+                description: 'Downloads the shipments datagrid as a csv, xls or xlsx file — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Pick the file type with ?format=csv|xls|xlsx (default csv).',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only csv.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV file downloaded (text/csv attachment).', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment.', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks the view permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/Models/AdminTransaction.php
+++ b/src/Admin/Models/AdminTransaction.php
@@ -86,19 +86,19 @@ use Webkul\BagistoApi\Admin\State\AdminTransactionItemProvider;
         new Get(
             uriTemplate: '/transactions/export',
             provider: AdminTransactionExportProvider::class,
-            outputFormats: ['csv' => ['text/csv']],
+            outputFormats: ['csv' => ['text/csv'], 'xls' => ['application/vnd.ms-excel'], 'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']],
             openapi: new Model\Operation(
                 tags: ['Admin Sales: Transactions'],
-                summary: 'Export transactions as CSV',
-                description: 'Downloads the transactions datagrid as a CSV file (text/csv attachment) — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Only ?format=csv is supported.',
+                summary: 'Export transactions as csv, xls or xlsx',
+                description: 'Downloads the transactions datagrid as a csv, xls or xlsx file — the same data the admin Export button produces. Honours the same filters as the listing. Binary download, not JSON. Pick the file type with ?format=csv|xls|xlsx (default csv).',
                 parameters: [
-                    new Model\Parameter('format', 'query', 'Export format. Currently only csv.', false, schema: ['type' => 'string', 'enum' => ['csv'], 'default' => 'csv']),
+                    new Model\Parameter('format', 'query', 'Export format: csv, xls or xlsx. Defaults to csv.', false, schema: ['type' => 'string', 'enum' => ['csv', 'xls', 'xlsx'], 'default' => 'csv']),
                 ],
                 responses: [
-                    '200' => new Model\Response(description: 'CSV file downloaded (text/csv attachment).', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
+                    '200' => new Model\Response(description: 'Export file downloaded as an attachment.', content: new \ArrayObject(['text/csv' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.ms-excel' => ['schema' => ['type' => 'string', 'format' => 'binary']], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => ['schema' => ['type' => 'string', 'format' => 'binary']]])),
                     '401' => new Model\Response(description: 'Missing or invalid admin token.'),
                     '403' => new Model\Response(description: 'Admin role lacks the view permission.'),
-                    '422' => new Model\Response(description: 'Unsupported format (only csv).'),
+                    '422' => new Model\Response(description: 'Unsupported format (csv, xls and xlsx only).'),
                 ],
             ),
         ),

--- a/src/Admin/State/AdminBookingExportProvider.php
+++ b/src/Admin/State/AdminBookingExportProvider.php
@@ -5,11 +5,11 @@ namespace Webkul\BagistoApi\Admin\State;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 class AdminBookingExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -18,7 +18,7 @@ class AdminBookingExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'bookings.csv';
+        return 'bookings';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminCatalogProductExportProvider.php
+++ b/src/Admin/State/AdminCatalogProductExportProvider.php
@@ -4,11 +4,11 @@ namespace Webkul\BagistoApi\Admin\State;
 
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 class AdminCatalogProductExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -17,7 +17,7 @@ class AdminCatalogProductExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'products.csv';
+        return 'products';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminCmsPageExportProvider.php
+++ b/src/Admin/State/AdminCmsPageExportProvider.php
@@ -4,11 +4,11 @@ namespace Webkul\BagistoApi\Admin\State;
 
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 class AdminCmsPageExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -17,7 +17,7 @@ class AdminCmsPageExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'cms-pages.csv';
+        return 'cms-pages';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminInvoiceExportProvider.php
+++ b/src/Admin/State/AdminInvoiceExportProvider.php
@@ -5,11 +5,11 @@ namespace Webkul\BagistoApi\Admin\State;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 class AdminInvoiceExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -18,7 +18,7 @@ class AdminInvoiceExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'invoices.csv';
+        return 'invoices';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminOrderExportProvider.php
+++ b/src/Admin/State/AdminOrderExportProvider.php
@@ -5,12 +5,12 @@ namespace Webkul\BagistoApi\Admin\State;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Facades\DB;
 use Webkul\BagistoApi\Admin\State\Concerns\ResolvesAdminDateRange;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 class AdminOrderExportProvider implements ProviderInterface
 {
     use ResolvesAdminDateRange;
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -19,7 +19,7 @@ class AdminOrderExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'orders.csv';
+        return 'orders';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminRefundExportProvider.php
+++ b/src/Admin/State/AdminRefundExportProvider.php
@@ -5,12 +5,12 @@ namespace Webkul\BagistoApi\Admin\State;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 use Webkul\Sales\Models\OrderAddress;
 
 class AdminRefundExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -19,7 +19,7 @@ class AdminRefundExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'refunds.csv';
+        return 'refunds';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminReportingExportProvider.php
+++ b/src/Admin/State/AdminReportingExportProvider.php
@@ -6,21 +6,23 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Http\Response;
 use Webkul\BagistoApi\Admin\Helper\AdminAuthHelper;
+use Webkul\BagistoApi\Admin\State\Concerns\BuildsAdminExportFile;
 use Webkul\BagistoApi\Exception\AuthenticationException;
-use Webkul\BagistoApi\Exception\InvalidInputException;
 
 /**
- * CSV export for a reporting sub-page (the admin Export button). REST only.
+ * File export for a reporting sub-page (the admin Export button). REST only.
  *
  * Mirrors `Reporting/Controller::export()` — runs the same `?type=` stat in its
- * table form ({ columns, records }) and streams it as CSV. The columns become
- * the header row; each record's column-keyed values become the data rows.
+ * table form ({ columns, records }) and streams it as csv, xls or xlsx. The columns
+ * become the header row; each record's column-keyed values become the data rows.
  * Reporting has no ACL permission gate, so only authentication is required.
  *
  * One concrete subclass per sub-page sets $entity (sales / customers / products).
  */
 abstract class AdminReportingExportProvider implements ProviderInterface
 {
+    use BuildsAdminExportFile;
+
     protected const EXPORT_MAX_ROWS = 50000;
 
     /** Sub-page: sales | customers | products. */
@@ -32,10 +34,7 @@ abstract class AdminReportingExportProvider implements ProviderInterface
             throw new AuthenticationException(__('bagistoapi::app.admin.profile.unauthenticated'));
         }
 
-        $format = strtolower((string) (request()->query('format') ?? 'csv'));
-        if ($format !== 'csv') {
-            throw new InvalidInputException(__('bagistoapi::app.admin.reporting.export-format-unsupported'), 422);
-        }
+        $format = $this->resolveExportFormat('bagistoapi::app.admin.reporting.export-format-unsupported');
 
         $type = request()->query('type');
 
@@ -45,33 +44,29 @@ abstract class AdminReportingExportProvider implements ProviderInterface
         $columns = $statistics['columns'] ?? [];
         $records = $statistics['records'] ?? [];
 
-        $handle = fopen('php://temp', 'r+');
+        $rows = [];
 
-        fputcsv($handle, array_map(static fn ($col) => $col['label'] ?? $col['key'] ?? '', $columns));
-
-        $count = 0;
         foreach ($records as $record) {
-            if ($count++ >= self::EXPORT_MAX_ROWS) {
+            if (count($rows) >= self::EXPORT_MAX_ROWS) {
                 break;
             }
 
             $row = [];
+
             foreach ($columns as $col) {
                 $key = $col['key'] ?? null;
                 $value = $key !== null ? ($record[$key] ?? '') : '';
                 $row[] = is_scalar($value) || $value === null ? $value : json_encode($value);
             }
 
-            fputcsv($handle, $row);
+            $rows[] = $row;
         }
 
-        rewind($handle);
-        $csv = stream_get_contents($handle);
-        fclose($handle);
-
-        return new Response($csv, 200, [
-            'Content-Type' => 'text/csv; charset=UTF-8',
-            'Content-Disposition' => 'attachment; filename="'.$this->entity.'-'.($payload['type'] ?? 'report').'.csv"',
-        ]);
+        return $this->buildExportResponse(
+            array_map(static fn ($col) => $col['label'] ?? $col['key'] ?? '', $columns),
+            $rows,
+            $this->entity.'-'.($payload['type'] ?? 'report'),
+            $format,
+        );
     }
 }

--- a/src/Admin/State/AdminSettingsTaxRateExportProvider.php
+++ b/src/Admin/State/AdminSettingsTaxRateExportProvider.php
@@ -4,7 +4,7 @@ namespace Webkul\BagistoApi\Admin\State;
 
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 /**
  * CSV export for the admin Settings → Tax Rates datagrid (the Export button).
@@ -15,7 +15,7 @@ use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
  */
 class AdminSettingsTaxRateExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -24,7 +24,7 @@ class AdminSettingsTaxRateExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'tax-rates.csv';
+        return 'tax-rates';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminShipmentExportProvider.php
+++ b/src/Admin/State/AdminShipmentExportProvider.php
@@ -5,12 +5,12 @@ namespace Webkul\BagistoApi\Admin\State;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 use Webkul\Sales\Models\OrderAddress;
 
 class AdminShipmentExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -19,7 +19,7 @@ class AdminShipmentExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'shipments.csv';
+        return 'shipments';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/AdminTransactionExportProvider.php
+++ b/src/Admin/State/AdminTransactionExportProvider.php
@@ -5,11 +5,11 @@ namespace Webkul\BagistoApi\Admin\State;
 use ApiPlatform\State\ProviderInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminCsvExport;
+use Webkul\BagistoApi\Admin\State\Concerns\StreamsAdminExport;
 
 class AdminTransactionExportProvider implements ProviderInterface
 {
-    use StreamsAdminCsvExport;
+    use StreamsAdminExport;
 
     protected function exportPermission(): string
     {
@@ -18,7 +18,7 @@ class AdminTransactionExportProvider implements ProviderInterface
 
     protected function exportFilename(): string
     {
-        return 'transactions.csv';
+        return 'transactions';
     }
 
     protected function exportHeaders(): array

--- a/src/Admin/State/Concerns/BuildsAdminExportFile.php
+++ b/src/Admin/State/Concerns/BuildsAdminExportFile.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Webkul\BagistoApi\Admin\State\Concerns;
+
+use Illuminate\Http\Response;
+use Maatwebsite\Excel\Excel as ExcelWriter;
+use Maatwebsite\Excel\Facades\Excel;
+use Webkul\BagistoApi\Admin\Exports\AdminGridExport;
+use Webkul\BagistoApi\Exception\InvalidInputException;
+
+trait BuildsAdminExportFile
+{
+    protected const EXPORT_FORMATS = ['csv', 'xls', 'xlsx'];
+
+    protected const EXPORT_MIME_TYPES = [
+        'csv' => 'text/csv; charset=UTF-8',
+        'xls' => 'application/vnd.ms-excel',
+        'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ];
+
+    protected function resolveExportFormat(string $unsupportedLangKey): string
+    {
+        $format = strtolower((string) (request()->query('format') ?? 'csv'));
+
+        if (! in_array($format, self::EXPORT_FORMATS, true)) {
+            throw new InvalidInputException(__($unsupportedLangKey), 422);
+        }
+
+        return $format;
+    }
+
+    protected function buildExportResponse(array $headings, array $rows, string $baseName, string $format): Response
+    {
+        $headings = array_map(fn ($value) => $this->sanitizeExportValue($value), $headings);
+        $rows = array_map(fn ($row) => array_map(fn ($value) => $this->sanitizeExportValue($value), $row), $rows);
+
+        $body = match ($format) {
+            'xls' => Excel::raw(new AdminGridExport($headings, $rows), ExcelWriter::XLS),
+            'xlsx' => Excel::raw(new AdminGridExport($headings, $rows), ExcelWriter::XLSX),
+            default => $this->toCsvString($headings, $rows),
+        };
+
+        return new Response($body, 200, [
+            'Content-Type' => self::EXPORT_MIME_TYPES[$format],
+            'Content-Disposition' => 'attachment; filename="'.$baseName.'.'.$format.'"',
+        ]);
+    }
+
+    protected function toCsvString(array $headings, array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+
+        fputcsv($handle, $headings);
+
+        foreach ($rows as $row) {
+            fputcsv($handle, $row);
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle);
+        fclose($handle);
+
+        return $csv;
+    }
+
+    /**
+     * Guard against spreadsheet formula injection, mirroring the core datagrid export.
+     */
+    protected function sanitizeExportValue(mixed $value): mixed
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        $trimmed = ltrim($value);
+
+        if ($trimmed === '') {
+            return $value;
+        }
+
+        if (preg_match('/^[=+\-@|%\t\r\n]/u', $trimmed)) {
+            return "'".$value;
+        }
+
+        return $value;
+    }
+}

--- a/src/Admin/State/Concerns/StreamsAdminExport.php
+++ b/src/Admin/State/Concerns/StreamsAdminExport.php
@@ -4,10 +4,10 @@ namespace Webkul\BagistoApi\Admin\State\Concerns;
 
 use ApiPlatform\Metadata\Operation;
 use Illuminate\Http\Response;
-use Webkul\BagistoApi\Exception\InvalidInputException;
 
-trait StreamsAdminCsvExport
+trait StreamsAdminExport
 {
+    use BuildsAdminExportFile;
     use ChecksAdminPermission;
 
     protected const EXPORT_MAX_ROWS = 50000;
@@ -16,33 +16,23 @@ trait StreamsAdminCsvExport
     {
         $this->authorizedAdmin($this->exportPermission());
 
-        $format = strtolower((string) (request()->query('format') ?? 'csv'));
-        if ($format !== 'csv') {
-            throw new InvalidInputException(__('bagistoapi::app.admin.sales.export.format-unsupported'), 422);
-        }
+        $format = $this->resolveExportFormat('bagistoapi::app.admin.sales.export.format-unsupported');
 
         $rows = $this->exportQuery(request()->query())->limit(self::EXPORT_MAX_ROWS)->get();
 
-        $handle = fopen('php://temp', 'r+');
-
-        fputcsv($handle, $this->exportHeaders());
-
-        foreach ($rows as $row) {
-            fputcsv($handle, $this->exportRow($row));
-        }
-
-        rewind($handle);
-        $csv = stream_get_contents($handle);
-        fclose($handle);
-
-        return new Response($csv, 200, [
-            'Content-Type' => 'text/csv; charset=UTF-8',
-            'Content-Disposition' => 'attachment; filename="'.$this->exportFilename().'"',
-        ]);
+        return $this->buildExportResponse(
+            $this->exportHeaders(),
+            $rows->map(fn ($row) => array_values($this->exportRow($row)))->all(),
+            $this->exportFilename(),
+            $format,
+        );
     }
 
     abstract protected function exportPermission(): string;
 
+    /**
+     * File name without the extension — the requested format supplies it.
+     */
     abstract protected function exportFilename(): string;
 
     abstract protected function exportHeaders(): array;

--- a/src/Console/Commands/PruneCartUploadsCommand.php
+++ b/src/Console/Commands/PruneCartUploadsCommand.php
@@ -19,15 +19,13 @@ class PruneCartUploadsCommand extends Command
 
     public function handle(CartOptionFileStaging $staging): int
     {
-        $config = $staging->config();
+        $disk = Storage::disk(CartOptionFileStaging::DISK);
 
-        $disk = Storage::disk($config['disk']);
-
-        $cutoff = now()->subMinutes((int) $config['ttl_minutes'])->getTimestamp();
+        $cutoff = now()->subMinutes($staging->ttlMinutes())->getTimestamp();
 
         $deleted = 0;
 
-        foreach ($disk->files($config['stage_dir']) as $file) {
+        foreach ($disk->files(CartOptionFileStaging::STAGE_DIR) as $file) {
             if ($disk->lastModified($file) < $cutoff) {
                 $disk->delete($file);
 

--- a/src/Dto/CartData.php
+++ b/src/Dto/CartData.php
@@ -4,6 +4,7 @@ namespace Webkul\BagistoApi\Dto;
 
 use ApiPlatform\Metadata\ApiProperty;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Webkul\BagistoApi\Models\GuestCartTokens;
 use Webkul\Checkout\Models\Cart;
 use Webkul\Tax\Facades\Tax;
 
@@ -218,7 +219,7 @@ class CartData
         $data = new self;
 
         $data->id = $cart->id;
-        $data->cartToken = (string) $cart->id;
+        $data->cartToken = GuestCartTokens::where('cart_id', $cart->id)->orderByDesc('id')->value('token');
         $data->customerId = $cart->customer_id;
         $data->isGuest = ! $cart->customer_id;
         $data->channelId = $cart->channel_id;
@@ -341,6 +342,10 @@ class CartData
     {
         $this->items = $items;
     }
+
+    #[Groups(['query', 'mutation'])]
+    #[ApiProperty(description: 'True when the selected payment method requires the shopper to be sent to a payment page before the order is created')]
+    public ?bool $redirect = false;
 
     #[Groups(['query', 'mutation'])]
     #[ApiProperty(description: 'Redirect URL for payment gateway')]

--- a/src/Http/Controllers/GraphQLPlaygroundController.php
+++ b/src/Http/Controllers/GraphQLPlaygroundController.php
@@ -15,8 +15,8 @@ class GraphQLPlaygroundController extends Controller
      */
     public function __invoke()
     {
-        $storefrontKey = env('STOREFRONT_PLAYGROUND_KEY', 'pk_storefront_xxxxx');
-        $autoInjectKey = filter_var(env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', 'true'), FILTER_VALIDATE_BOOLEAN);
+        $storefrontKey = config('storefront.playground_key') ?: 'pk_storefront_xxxxx';
+        $autoInjectKey = filter_var(config('storefront.auto_inject_playground_key'), FILTER_VALIDATE_BOOLEAN);
 
         return new Response($this->getGraphQLPlaygroundHTML($storefrontKey, $autoInjectKey), 200, [
             'Content-Type' => 'text/html; charset=UTF-8',

--- a/src/Http/Middleware/VerifyGraphQLStorefrontKey.php
+++ b/src/Http/Middleware/VerifyGraphQLStorefrontKey.php
@@ -391,7 +391,7 @@ class VerifyGraphQLStorefrontKey
      */
     protected function injectHeaderScript(Response $response): Response
     {
-        $storefrontKey = env('STOREFRONT_PLAYGROUND_KEY') ?? 'pk_storefront_xxxxx';
+        $storefrontKey = config('storefront.playground_key') ?: 'pk_storefront_xxxxx';
 
         $script = <<<'JS'
 <script>

--- a/src/Metadata/SourceDocblockPropertyMetadataFactory.php
+++ b/src/Metadata/SourceDocblockPropertyMetadataFactory.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Webkul\BagistoApi\Metadata;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ReflectionClass;
+use ReflectionProperty;
+use Symfony\Component\TypeInfo\Type as NativeType;
+
+/**
+ * Restores the element type of `@var array<Foo>` / `Foo[]` DTO properties when the
+ * runtime docblock is unavailable.
+ *
+ * php-fpm built with `opcache.save_comments=0` strips doc comments from bytecode, so
+ * Reflection::getDocComment() returns false and symfony/type-info cannot read the
+ * generic element type — a `?array $items` property then resolves to the GraphQL
+ * `Iterable` scalar instead of a `[CartItem]` connection. This factory re-reads the
+ * element class from the class SOURCE FILE (comments intact on disk, OPcache-immune)
+ * and re-applies the collection type. No-op when the decorated factory already carries
+ * the object element type (CLI / save_comments=1).
+ */
+class SourceDocblockPropertyMetadataFactory implements PropertyMetadataFactoryInterface
+{
+    private const NAMESPACE_PREFIX = 'Webkul\\BagistoApi\\';
+
+    /** @var array<class-string, array{ns:string, uses:array<string,string>, docs:array<string,string>}> */
+    private static array $fileCache = [];
+
+    public function __construct(private readonly PropertyMetadataFactoryInterface $decorated) {}
+
+    public function create(string $resourceClass, string $property, array $options = []): ApiProperty
+    {
+        $metadata = $this->decorated->create($resourceClass, $property, $options);
+
+        if (! str_starts_with($resourceClass, self::NAMESPACE_PREFIX)) {
+            return $metadata;
+        }
+
+        if ($this->alreadyHasObjectElement($metadata)) {
+            return $metadata;
+        }
+
+        if (! $this->isArrayTyped($resourceClass, $property, $allowsNull)) {
+            return $metadata;
+        }
+
+        $elementClass = $this->elementClassFromSource($resourceClass, $property);
+
+        if ($elementClass === null) {
+            return $metadata;
+        }
+
+        $native = NativeType::array(NativeType::object($elementClass));
+
+        if ($allowsNull) {
+            $native = NativeType::nullable($native);
+        }
+
+        return $metadata->withNativeType($native);
+    }
+
+    /** True when the decorated metadata already exposes a class element type (docblock was readable). */
+    private function alreadyHasObjectElement(ApiProperty $metadata): bool
+    {
+        $native = $metadata->getNativeType();
+
+        if ($native !== null && str_contains((string) $native, '\\')) {
+            return true;
+        }
+
+        foreach ($metadata->getBuiltinTypes() ?? [] as $type) {
+            foreach ($type->getCollectionValueTypes() as $value) {
+                if ($value->getClassName() !== null) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isArrayTyped(string $class, string $property, ?bool &$allowsNull): bool
+    {
+        $allowsNull = false;
+
+        try {
+            $rp = new ReflectionProperty($class, $property);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        $type = $rp->getType();
+
+        if ($type === null) {
+            return false;
+        }
+
+        $allowsNull = $type->allowsNull();
+
+        $name = $type instanceof \ReflectionNamedType ? $type->getName() : (string) $type;
+
+        return in_array($name, ['array', 'iterable'], true);
+    }
+
+    private function elementClassFromSource(string $class, string $property): ?string
+    {
+        $parsed = $this->parseFile($class);
+
+        if ($parsed === null || ! isset($parsed['docs'][$property])) {
+            return null;
+        }
+
+        if (! preg_match('/@var\s+([^\s*]+)/', $parsed['docs'][$property], $m)) {
+            return null;
+        }
+
+        $element = $this->elementFromVar($m[1]);
+
+        if ($element === null) {
+            return null;
+        }
+
+        $fqcn = $this->resolveClass($element, $parsed['ns'], $parsed['uses']);
+
+        return $fqcn !== null && (class_exists($fqcn) || interface_exists($fqcn)) ? $fqcn : null;
+    }
+
+    /** Extract the element type from an `@var` expression: array<X>, array<int,X>, X[], X[]|null. */
+    private function elementFromVar(string $var): ?string
+    {
+        $var = trim($var);
+
+        // Drop a trailing |null / |int etc — keep the array-ish part.
+        foreach (explode('|', $var) as $part) {
+            $part = trim($part);
+
+            if ($part === '' || strcasecmp($part, 'null') === 0) {
+                continue;
+            }
+
+            if (preg_match('/^array<(.+)>$/i', $part, $m)) {
+                $inner = $m[1];
+                $segments = explode(',', $inner);
+                $value = trim(end($segments));
+
+                return $this->cleanType($value);
+            }
+
+            if (preg_match('/^(.+)\[\]$/', $part, $m)) {
+                return $this->cleanType($m[1]);
+            }
+        }
+
+        return null;
+    }
+
+    private function cleanType(string $type): ?string
+    {
+        $type = trim($type);
+        $type = preg_replace('/<.*>$/', '', $type);   // strip a nested generic
+        $type = rtrim($type, '[]');
+
+        if ($type === '' || in_array(strtolower($type), ['int', 'string', 'float', 'bool', 'mixed', 'array', 'object'], true)) {
+            return null;
+        }
+
+        return $type;
+    }
+
+    private function resolveClass(string $name, string $namespace, array $uses): ?string
+    {
+        if (str_starts_with($name, '\\')) {
+            return ltrim($name, '\\');
+        }
+
+        $segments = explode('\\', $name);
+        $first = $segments[0];
+
+        if (isset($uses[$first])) {
+            $segments[0] = $uses[$first];
+
+            return implode('\\', $segments);
+        }
+
+        if (class_exists($name) || interface_exists($name)) {
+            return $name;
+        }
+
+        return $namespace !== '' ? $namespace.'\\'.$name : $name;
+    }
+
+    /**
+     * @return array{ns:string, uses:array<string,string>, docs:array<string,string>}|null
+     */
+    private function parseFile(string $class): ?array
+    {
+        if (array_key_exists($class, self::$fileCache)) {
+            return self::$fileCache[$class] ?: null;
+        }
+
+        try {
+            $file = (new ReflectionClass($class))->getFileName();
+        } catch (\Throwable) {
+            $file = false;
+        }
+
+        if ($file === false || ! is_string($file) || ! is_readable($file)) {
+            return self::$fileCache[$class] = ['ns' => '', 'uses' => [], 'docs' => []];
+        }
+
+        $tokens = token_get_all(file_get_contents($file));
+
+        $ns = '';
+        $uses = [];
+        $docs = [];
+        $lastDoc = null;
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $t = $tokens[$i];
+
+            if (is_array($t)) {
+                switch ($t[0]) {
+                    case T_DOC_COMMENT:
+                        $lastDoc = $t[1];
+                        break;
+
+                    case T_NAMESPACE:
+                        $ns = $this->readName($tokens, $i);
+                        break;
+
+                    case T_USE:
+                        $this->readUse($tokens, $i, $uses);
+                        break;
+
+                    case T_VARIABLE:
+                        $name = ltrim($t[1], '$');
+                        if ($lastDoc !== null && ! isset($docs[$name])) {
+                            $docs[$name] = $lastDoc;
+                        }
+                        $lastDoc = null;
+                        break;
+                }
+
+                continue;
+            }
+
+            if ($t === ';' || $t === '{' || $t === '}') {
+                $lastDoc = null;
+            }
+        }
+
+        return self::$fileCache[$class] = compact('ns', 'uses', 'docs');
+    }
+
+    /** Read a namespace / qualified name starting at token $i, advancing $i past it. */
+    private function readName(array $tokens, int &$i): string
+    {
+        $name = '';
+        $count = count($tokens);
+
+        for ($i++; $i < $count; $i++) {
+            $t = $tokens[$i];
+
+            if (is_array($t)) {
+                if (in_array($t[0], [T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true)) {
+                    $name .= $t[1];
+
+                    continue;
+                }
+
+                if ($t[0] === T_WHITESPACE) {
+                    continue;
+                }
+            }
+
+            break;
+        }
+
+        return trim($name, '\\');
+    }
+
+    /** Parse a `use A\B\C;` / `use A\B\C as D;` statement into the alias map. */
+    private function readUse(array $tokens, int &$i, array &$uses): void
+    {
+        $name = '';
+        $alias = '';
+        $seenAs = false;
+        $count = count($tokens);
+
+        for ($i++; $i < $count; $i++) {
+            $t = $tokens[$i];
+
+            if ($t === ';' || $t === '{' || $t === ',') {
+                break;
+            }
+
+            if (is_array($t)) {
+                if ($t[0] === T_AS) {
+                    $seenAs = true;
+
+                    continue;
+                }
+
+                if (in_array($t[0], [T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true)) {
+                    if ($seenAs) {
+                        $alias .= $t[1];
+                    } else {
+                        $name .= $t[1];
+                    }
+                }
+            }
+        }
+
+        $name = trim($name, '\\');
+
+        if ($name === '') {
+            return;
+        }
+
+        $short = $alias !== '' ? $alias : substr(strrchr('\\'.$name, '\\'), 1);
+        $uses[$short] = $name;
+    }
+}

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -13,6 +13,8 @@ use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\Response;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Webkul\BagistoApi\Resolver\BaseQueryItemResolver;
 use Webkul\BagistoApi\Resolver\CategoryCollectionResolver;
 use Webkul\BagistoApi\State\CategoryRestProvider;
@@ -134,6 +136,53 @@ use Webkul\Category\Models\Category as BaseCategory;
 )]
 class Category extends BaseCategory
 {
+    protected $appends = ['logo_url', 'banner_url', 'url', 'min_price', 'max_price'];
+
+    private ?array $categoryPriceRange = null;
+
+    /**
+     * Lowest product price in this category for the requesting customer's group.
+     */
+    #[ApiProperty(description: 'Lowest product price in this category for the requesting customer group')]
+    public function getMinPriceAttribute(): float
+    {
+        return $this->resolvePriceRange()['min'];
+    }
+
+    /**
+     * Highest product price in this category for the requesting customer's group.
+     */
+    #[ApiProperty(description: 'Highest product price in this category for the requesting customer group')]
+    public function getMaxPriceAttribute(): float
+    {
+        return $this->resolvePriceRange()['max'];
+    }
+
+    private function resolvePriceRange(): array
+    {
+        if ($this->categoryPriceRange !== null) {
+            return $this->categoryPriceRange;
+        }
+
+        $customer = Auth::guard('sanctum')->user();
+
+        $customerGroup = ($customer && $customer->group)
+            ? $customer->group
+            : core()->getGuestCustomerGroup();
+
+        $range = DB::table('product_price_indices')
+            ->join('product_categories', 'product_categories.product_id', '=', 'product_price_indices.product_id')
+            ->where('product_price_indices.customer_group_id', $customerGroup->id)
+            ->where('product_categories.category_id', $this->id)
+            ->selectRaw('MIN(min_price) as min_price, MAX(min_price) as max_price')
+            ->first();
+
+        return $this->categoryPriceRange = [
+            'min' => (float) ($range->min_price ?? 0),
+            'max' => (float) ($range->max_price ?? 0),
+        ];
+    }
+
     /**
      * Get category translation for the current locale
      */

--- a/src/Models/CheckoutOrder.php
+++ b/src/Models/CheckoutOrder.php
@@ -53,16 +53,29 @@ use Webkul\BagistoApi\State\CheckoutProcessor;
                 ),
                 responses: [
                     201 => new Response(
-                        description: 'Order placed successfully.',
+                        description: 'Order placed, or a payment redirect is required. Check the `redirect` flag: when it is false the order exists and `orderId` is set; when it is true no order has been created yet and the shopper must be sent to `redirectUrl` to pay — the order is created once the gateway returns.',
                         content: new \ArrayObject([
                             'application/json' => [
-                                'example' => [
-                                    'id' => 6887,
-                                    'cartToken' => '1536',
-                                    'orderId' => '2609',
-                                    'success' => true,
-                                    'message' => 'Order placed successfully',
-                                ],
+                                'examples' => new \ArrayObject([
+                                    'Order placed (cash on delivery, money transfer)' => [
+                                        'value' => [
+                                            'id' => 6887,
+                                            'cartToken' => '1536',
+                                            'orderId' => '2609',
+                                            'redirect' => false,
+                                            'redirectUrl' => null,
+                                        ],
+                                    ],
+                                    'Payment redirect required (stripe, razorpay, payu, phonepe, paypal_standard)' => [
+                                        'value' => [
+                                            'id' => 6887,
+                                            'cartToken' => '1536',
+                                            'orderId' => null,
+                                            'redirect' => true,
+                                            'redirectUrl' => 'https://example.com/stripe/redirect',
+                                        ],
+                                    ],
+                                ]),
                             ],
                         ]),
                     ),
@@ -103,4 +116,12 @@ class CheckoutOrder
     #[ApiProperty(readable: true, writable: false)]
     #[Groups(['query', 'mutation'])]
     public ?string $orderId = null;
+
+    #[ApiProperty(readable: true, writable: false, description: 'True when the selected payment method requires the shopper to be sent to a payment page before the order is created.')]
+    #[Groups(['query', 'mutation'])]
+    public ?bool $redirect = false;
+
+    #[ApiProperty(readable: true, writable: false, description: 'Payment page to open when redirect is true. Null otherwise.')]
+    #[Groups(['query', 'mutation'])]
+    public ?string $redirectUrl = null;
 }

--- a/src/Models/CustomerReturn.php
+++ b/src/Models/CustomerReturn.php
@@ -12,6 +12,7 @@ use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\RequestBody;
+use ApiPlatform\OpenApi\Model\Response;
 use Webkul\BagistoApi\Contracts\SnakeCaseFieldsResource;
 use Webkul\BagistoApi\Dto\CreateCustomerReturnInput;
 use Webkul\BagistoApi\Dto\CustomerReturnActionInput;
@@ -30,6 +31,45 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
                 tags: ['Customer Return'],
                 summary: 'List the authenticated customer\'s return (RMA) requests',
                 description: 'Returns the customer\'s own RMA requests, newest first. Optional `?status=<id>` filter. Requires a customer Bearer token.',
+                responses: [
+                    '200' => new Response(
+                        description: 'The customer\'s return requests (detail-only fields — canClose/canReopen/isExpired/images — are null on the listing).',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    [
+                                        'id' => 12,
+                                        'orderId' => 45,
+                                        'orderIncrementId' => '000000045',
+                                        'statusId' => 1,
+                                        'statusTitle' => 'Pending',
+                                        'statusColor' => '#FDB022',
+                                        'packageCondition' => 'opened',
+                                        'information' => 'Item arrived damaged.',
+                                        'canClose' => null,
+                                        'canReopen' => null,
+                                        'isExpired' => null,
+                                        'item' => [
+                                            'id' => 30,
+                                            'order_item_id' => 78,
+                                            'sku' => 'COASTALBREEZEMENSHOODIE',
+                                            'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                            'quantity' => 1,
+                                            'resolution' => 'return',
+                                            'reason_id' => 2,
+                                            'reason' => 'Damaged product',
+                                            'variant_id' => null,
+                                        ],
+                                        'images' => null,
+                                        'messagesCount' => 2,
+                                        'createdAt' => '2026-07-20T10:15:30+00:00',
+                                        'updatedAt' => '2026-07-20T10:15:30+00:00',
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Get(
@@ -39,6 +79,49 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
                 tags: ['Customer Return'],
                 summary: 'Get one of the customer\'s return (RMA) requests',
                 description: 'Full detail of a single RMA owned by the authenticated customer — the returned item, images, status, and action flags (canClose / canReopen / isExpired). 404 if it is not the customer\'s.',
+                responses: [
+                    '200' => new Response(
+                        description: 'The return request detail.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 1,
+                                    'statusTitle' => 'Pending',
+                                    'statusColor' => '#FDB022',
+                                    'packageCondition' => 'opened',
+                                    'information' => 'Item arrived damaged.',
+                                    'canClose' => true,
+                                    'canReopen' => false,
+                                    'isExpired' => false,
+                                    'item' => [
+                                        'id' => 30,
+                                        'order_item_id' => 78,
+                                        'sku' => 'COASTALBREEZEMENSHOODIE',
+                                        'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                        'quantity' => 1,
+                                        'resolution' => 'return',
+                                        'reason_id' => 2,
+                                        'reason' => 'Damaged product',
+                                        'variant_id' => null,
+                                    ],
+                                    'images' => [
+                                        [
+                                            'id' => 5,
+                                            'path' => 'rma/12/damage-front.png',
+                                            'url' => 'https://example.com/storage/rma/12/damage-front.png',
+                                        ],
+                                    ],
+                                    'messagesCount' => 2,
+                                    'createdAt' => '2026-07-20T10:15:30+00:00',
+                                    'updatedAt' => '2026-07-20T10:15:30+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -69,6 +152,43 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
                         ],
                     ]),
                 ),
+                responses: [
+                    '201' => new Response(
+                        description: 'The created return request.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 1,
+                                    'statusTitle' => 'Pending',
+                                    'statusColor' => '#FDB022',
+                                    'packageCondition' => 'opened',
+                                    'information' => 'Item arrived damaged.',
+                                    'canClose' => true,
+                                    'canReopen' => false,
+                                    'isExpired' => false,
+                                    'item' => [
+                                        'id' => 30,
+                                        'order_item_id' => 78,
+                                        'sku' => 'COASTALBREEZEMENSHOODIE',
+                                        'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                        'quantity' => 1,
+                                        'resolution' => 'return',
+                                        'reason_id' => 2,
+                                        'reason' => 'Damaged product',
+                                        'variant_id' => null,
+                                    ],
+                                    'images' => [],
+                                    'messagesCount' => 0,
+                                    'createdAt' => '2026-07-20T10:15:30+00:00',
+                                    'updatedAt' => '2026-07-20T10:15:30+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -79,6 +199,28 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
                 tags: ['Customer Return'],
                 summary: 'Cancel a return request',
                 description: 'Cancels the customer\'s own RMA (unless it is already canceled). Empty body. Returns the updated RMA.',
+                responses: [
+                    '200' => new Response(
+                        description: 'The canceled return request.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 4,
+                                    'statusTitle' => 'Canceled',
+                                    'statusColor' => '#F04438',
+                                    'canClose' => false,
+                                    'canReopen' => true,
+                                    'isExpired' => false,
+                                    'messagesCount' => 2,
+                                    'updatedAt' => '2026-07-20T11:00:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -89,6 +231,28 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
                 tags: ['Customer Return'],
                 summary: 'Reopen a return request',
                 description: 'Reopens a canceled/declined RMA back to pending — only when store settings allow it (otherwise 400). Empty body. Returns the updated RMA.',
+                responses: [
+                    '200' => new Response(
+                        description: 'The reopened return request.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 1,
+                                    'statusTitle' => 'Pending',
+                                    'statusColor' => '#FDB022',
+                                    'canClose' => true,
+                                    'canReopen' => false,
+                                    'isExpired' => false,
+                                    'messagesCount' => 2,
+                                    'updatedAt' => '2026-07-20T11:05:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -99,6 +263,28 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
                 tags: ['Customer Return'],
                 summary: 'Close (mark solved) a return request',
                 description: 'Marks the customer\'s own RMA as solved and adds a conversation note. Empty body. Returns the updated RMA.',
+                responses: [
+                    '200' => new Response(
+                        description: 'The closed (solved) return request.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 12,
+                                    'orderId' => 45,
+                                    'orderIncrementId' => '000000045',
+                                    'statusId' => 3,
+                                    'statusTitle' => 'Solved',
+                                    'statusColor' => '#12B76A',
+                                    'canClose' => false,
+                                    'canReopen' => false,
+                                    'isExpired' => false,
+                                    'messagesCount' => 3,
+                                    'updatedAt' => '2026-07-20T11:10:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Models/CustomerReturn.php
+++ b/src/Models/CustomerReturn.php
@@ -196,6 +196,15 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
             processor: CustomerReturnProcessor::class,
             read: false,
             openapi: new Operation(
+                requestBody: new RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                            'example' => new \stdClass,
+                        ],
+                    ]),
+                ),
                 tags: ['Customer Return'],
                 summary: 'Cancel a return request',
                 description: 'Cancels the customer\'s own RMA (unless it is already canceled). Empty body. Returns the updated RMA.',
@@ -228,6 +237,15 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
             processor: CustomerReturnProcessor::class,
             read: false,
             openapi: new Operation(
+                requestBody: new RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                            'example' => new \stdClass,
+                        ],
+                    ]),
+                ),
                 tags: ['Customer Return'],
                 summary: 'Reopen a return request',
                 description: 'Reopens a canceled/declined RMA back to pending — only when store settings allow it (otherwise 400). Empty body. Returns the updated RMA.',
@@ -260,6 +278,15 @@ use Webkul\BagistoApi\State\CustomerReturnProvider;
             processor: CustomerReturnProcessor::class,
             read: false,
             openapi: new Operation(
+                requestBody: new RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                            'example' => new \stdClass,
+                        ],
+                    ]),
+                ),
                 tags: ['Customer Return'],
                 summary: 'Close (mark solved) a return request',
                 description: 'Marks the customer\'s own RMA as solved and adds a conversation note. Empty body. Returns the updated RMA.',

--- a/src/Models/CustomerReturnMessage.php
+++ b/src/Models/CustomerReturnMessage.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
 use ApiPlatform\OpenApi\Model\RequestBody;
+use ApiPlatform\OpenApi\Model\Response;
 use Illuminate\Support\Facades\Storage;
 use Webkul\BagistoApi\Contracts\SnakeCaseFieldsResource;
 use Webkul\BagistoApi\Dto\SendCustomerReturnMessageInput;
@@ -32,6 +33,35 @@ use Webkul\BagistoApi\State\CustomerReturnMessageProvider;
                 description: 'Messages on the RMA named by `?return_id=`, newest first. Requires the RMA to belong to the authenticated customer.',
                 parameters: [
                     new Parameter('return_id', 'query', 'Return (RMA) id', true, schema: ['type' => 'integer']),
+                ],
+                responses: [
+                    '200' => new Response(
+                        description: 'The RMA conversation messages, newest first.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    [
+                                        'id' => 88,
+                                        'rmaId' => 12,
+                                        'message' => 'We have received your request and will inspect the item.',
+                                        'isAdmin' => true,
+                                        'attachment' => null,
+                                        'attachmentUrl' => null,
+                                        'createdAt' => '2026-07-20T10:40:00+00:00',
+                                    ],
+                                    [
+                                        'id' => 87,
+                                        'rmaId' => 12,
+                                        'message' => 'The hoodie zipper is broken.',
+                                        'isAdmin' => false,
+                                        'attachment' => 'rma/12/messages/zipper.jpg',
+                                        'attachmentUrl' => 'https://example.com/storage/rma/12/messages/zipper.jpg',
+                                        'createdAt' => '2026-07-20T10:20:00+00:00',
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
                 ],
             ),
         ),
@@ -57,6 +87,24 @@ use Webkul\BagistoApi\State\CustomerReturnMessageProvider;
                         ],
                     ]),
                 ),
+                responses: [
+                    '201' => new Response(
+                        description: 'The created message.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 89,
+                                    'rmaId' => 12,
+                                    'message' => 'Any update on my return?',
+                                    'isAdmin' => false,
+                                    'attachment' => null,
+                                    'attachmentUrl' => null,
+                                    'createdAt' => '2026-07-20T11:15:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Models/EuWithdrawal.php
+++ b/src/Models/EuWithdrawal.php
@@ -28,6 +28,35 @@ use Webkul\BagistoApi\State\EuWithdrawalProvider;
                 tags: ['EU Withdrawal'],
                 summary: 'List the authenticated customer\'s EU right-of-withdrawal declarations',
                 description: 'Returns the customer\'s own withdrawal declarations, newest first. Requires a customer Bearer token.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The customer\'s withdrawal declarations.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    [
+                                        'id' => 7,
+                                        'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                        'orderId' => 12,
+                                        'orderIncrementId' => '000000012',
+                                        'isGuest' => false,
+                                        'customerEmail' => 'jane@example.com',
+                                        'status' => 'received',
+                                        'reasonText' => 'Changed my mind.',
+                                        'receivedAt' => '2026-07-20T09:00:00+00:00',
+                                        'confirmationSentAt' => '2026-07-20T09:00:05+00:00',
+                                        'declinedAt' => null,
+                                        'declinedReason' => null,
+                                        'refundedAt' => null,
+                                        'refundNote' => null,
+                                        'createdAt' => '2026-07-20T09:00:00+00:00',
+                                        'updatedAt' => '2026-07-20T09:00:05+00:00',
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Get(
@@ -38,6 +67,33 @@ use Webkul\BagistoApi\State\EuWithdrawalProvider;
                 tags: ['EU Withdrawal'],
                 summary: 'Get one of the customer\'s withdrawal declarations',
                 description: 'Full detail of a single withdrawal owned by the authenticated customer (ownership via the underlying order). 404 if it is not the customer\'s.',
+                responses: [
+                    '200' => new Model\Response(
+                        description: 'The withdrawal declaration detail.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 7,
+                                    'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                    'orderId' => 12,
+                                    'orderIncrementId' => '000000012',
+                                    'isGuest' => false,
+                                    'customerEmail' => 'jane@example.com',
+                                    'status' => 'received',
+                                    'reasonText' => 'Changed my mind.',
+                                    'receivedAt' => '2026-07-20T09:00:00+00:00',
+                                    'confirmationSentAt' => '2026-07-20T09:00:05+00:00',
+                                    'declinedAt' => null,
+                                    'declinedReason' => null,
+                                    'refundedAt' => null,
+                                    'refundNote' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:05+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
         new Post(
@@ -62,6 +118,33 @@ use Webkul\BagistoApi\State\EuWithdrawalProvider;
                         ],
                     ]),
                 ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created (or existing, idempotent) withdrawal declaration.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 7,
+                                    'uuid' => 'b2f1c0de-5a2e-4d7a-9f2e-3c1a2b4d5e6f',
+                                    'orderId' => 12,
+                                    'orderIncrementId' => '000000012',
+                                    'isGuest' => false,
+                                    'customerEmail' => 'jane@example.com',
+                                    'status' => 'received',
+                                    'reasonText' => 'Changed my mind.',
+                                    'receivedAt' => '2026-07-20T09:00:00+00:00',
+                                    'confirmationSentAt' => '2026-07-20T09:00:05+00:00',
+                                    'declinedAt' => null,
+                                    'declinedReason' => null,
+                                    'refundedAt' => null,
+                                    'refundNote' => null,
+                                    'createdAt' => '2026-07-20T09:00:00+00:00',
+                                    'updatedAt' => '2026-07-20T09:00:05+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Models/GdprRequest.php
+++ b/src/Models/GdprRequest.php
@@ -166,6 +166,15 @@ use Webkul\GDPR\Models\GDPRDataRequest;
             status: 200,
             processor: GdprRequestProcessor::class,
             openapi: new Operation(
+                requestBody: new RequestBody(
+                    required: false,
+                    content: new \ArrayObject([
+                        'application/json' => [
+                            'schema' => ['type' => 'object'],
+                            'example' => new \stdClass,
+                        ],
+                    ]),
+                ),
                 tags: ['GDPR Requests'],
                 summary: 'Revoke a GDPR data request',
                 description: 'Revoke one of the customer\'s own GDPR data requests. Allowed only while the request is pending or processing. Send an empty JSON body `{}`.',

--- a/src/Models/GuestEuWithdrawal.php
+++ b/src/Models/GuestEuWithdrawal.php
@@ -40,6 +40,28 @@ use Webkul\BagistoApi\State\EuWithdrawalProcessor;
                         ],
                     ]),
                 ),
+                responses: [
+                    '201' => new Model\Response(
+                        description: 'The created (or existing, idempotent) guest withdrawal declaration.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    'id' => 9,
+                                    'uuid' => 'a1c2e3f4-6b7c-4d8e-9a0b-1c2d3e4f5a6b',
+                                    'orderId' => 34,
+                                    'orderIncrementId' => '1000123',
+                                    'isGuest' => true,
+                                    'customerEmail' => 'guest@example.com',
+                                    'status' => 'received',
+                                    'reasonText' => 'Changed my mind.',
+                                    'receivedAt' => '2026-07-20T09:30:00+00:00',
+                                    'confirmationSentAt' => '2026-07-20T09:30:05+00:00',
+                                    'createdAt' => '2026-07-20T09:30:00+00:00',
+                                ],
+                            ],
+                        ]),
+                    ),
+                ],
             ),
         ),
     ],

--- a/src/Models/ProductImage.php
+++ b/src/Models/ProductImage.php
@@ -152,7 +152,7 @@ class ProductImage extends BaseProductImage
     #[ApiProperty(readable: true, writable: false)]
     public function getPublicPathAttribute(): ?string
     {
-        return env('API_URL').$this->getUrlAttribute();
+        return $this->getUrlAttribute();
     }
 
     #[ApiProperty(identifier: true, writable: false)]

--- a/src/Models/ProductVideo.php
+++ b/src/Models/ProductVideo.php
@@ -148,7 +148,7 @@ class ProductVideo extends BaseProductVideo
     #[ApiProperty(readable: true, writable: false)]
     public function getPublicPathAttribute(): ?string
     {
-        return env('API_URL').$this->getUrlAttribute();
+        return $this->getUrlAttribute();
     }
 
     #[ApiProperty(identifier: true, writable: false)]

--- a/src/Models/ReturnReason.php
+++ b/src/Models/ReturnReason.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use ApiPlatform\OpenApi\Model\Response;
 use Webkul\BagistoApi\State\ReturnReasonProvider;
 
 #[ApiResource(
@@ -25,6 +26,20 @@ use Webkul\BagistoApi\State\ReturnReasonProvider;
                 description: 'Reasons a customer can pick when raising a return, filtered by `?resolution_type=return|cancel_items`. Use these ids as `rmaReasonId` when creating a return.',
                 parameters: [
                     new Parameter('resolution_type', 'query', 'return | cancel_items', true, schema: ['type' => 'string', 'enum' => ['return', 'cancel_items']]),
+                ],
+                responses: [
+                    '200' => new Response(
+                        description: 'Active reasons for the resolution type. Use an id as rmaReasonId when creating a return.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    ['id' => 2, 'title' => 'Damaged product', 'position' => 1],
+                                    ['id' => 3, 'title' => 'Wrong item delivered', 'position' => 2],
+                                    ['id' => 4, 'title' => 'No longer needed', 'position' => 3],
+                                ],
+                            ],
+                        ]),
+                    ),
                 ],
             ),
         ),

--- a/src/Models/ReturnableItem.php
+++ b/src/Models/ReturnableItem.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\OpenApi\Model\Operation;
 use ApiPlatform\OpenApi\Model\Parameter;
+use ApiPlatform\OpenApi\Model\Response;
 use Webkul\BagistoApi\State\ReturnableItemProvider;
 
 #[ApiResource(
@@ -25,6 +26,33 @@ use Webkul\BagistoApi\State\ReturnableItemProvider;
                 description: 'Items from the order named by `?order_id=` that are still within their return window and not already fully returned/canceled. Each row carries the trusted quantity caps (`forReturnQuantity`, `forCancelQuantity`, `currentQuantity`) the create endpoint enforces. Requires the order to belong to the authenticated customer.',
                 parameters: [
                     new Parameter('order_id', 'query', 'Order id to list returnable items for', true, schema: ['type' => 'integer']),
+                ],
+                responses: [
+                    '200' => new Response(
+                        description: 'The return-eligible items of the order, with server-enforced quantity caps.',
+                        content: new \ArrayObject([
+                            'application/json' => [
+                                'example' => [
+                                    [
+                                        'orderItemId' => 78,
+                                        'productId' => 1,
+                                        'sku' => 'COASTALBREEZEMENSHOODIE',
+                                        'name' => "Coastal Breeze Men's Blue Zipper Hoodie",
+                                        'type' => 'simple',
+                                        'urlKey' => 'coastal-breeze-mens-blue-zipper-hoodie',
+                                        'price' => 100,
+                                        'baseImageUrl' => 'https://example.com/storage/product/1/hoodie.webp',
+                                        'qtyOrdered' => 2,
+                                        'currentQuantity' => 2,
+                                        'forReturnQuantity' => 2,
+                                        'forCancelQuantity' => 0,
+                                        'rmaQuantity' => 0,
+                                        'rmaReturnPeriod' => 30,
+                                    ],
+                                ],
+                            ],
+                        ]),
+                    ),
                 ],
             ),
         ),

--- a/src/OpenApi/SplitOpenApiFactory.php
+++ b/src/OpenApi/SplitOpenApiFactory.php
@@ -59,6 +59,8 @@ class SplitOpenApiFactory implements OpenApiFactoryInterface
             $description = 'Bagisto Admin API - Administrative operations for store management and configuration.';
         }
 
+        $openApi = $this->cleanPathParameters($openApi);
+
         // Update the main description
         $openApi = $this->withDescription($openApi, $description);
 
@@ -82,6 +84,72 @@ class SplitOpenApiFactory implements OpenApiFactoryInterface
         }
 
         return $openApi;
+    }
+
+    /**
+     * Drop path parameters the route does not carry and replace auto-generated
+     * "<Resource> identifier" descriptions with consumer-facing wording.
+     */
+    private function cleanPathParameters(OpenApi $openApi): OpenApi
+    {
+        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
+        $paths = new Paths;
+
+        foreach ($openApi->getPaths()->getPaths() as $path => $pathItem) {
+            foreach ($methods as $method) {
+                $operation = $pathItem->{'get'.ucfirst($method)}();
+
+                if (! $operation) {
+                    continue;
+                }
+
+                $original = $operation->getParameters();
+                $parameters = [];
+
+                foreach ($original as $parameter) {
+                    if (
+                        $parameter->getIn() === 'path'
+                        && ! str_contains($path, '{'.$parameter->getName().'}')
+                    ) {
+                        continue;
+                    }
+
+                    $parameters[] = $this->withReadableParameterDescription($parameter);
+                }
+
+                if ($parameters == $original) {
+                    continue;
+                }
+
+                $pathItem = $pathItem->{'with'.ucfirst($method)}($operation->withParameters($parameters));
+            }
+
+            $paths->addPath($path, $pathItem);
+        }
+
+        return $openApi->withPaths($paths);
+    }
+
+    /**
+     * Rewrite "AdminOrderComment identifier" into "Order comment ID".
+     */
+    private function withReadableParameterDescription(Parameter $parameter): Parameter
+    {
+        if (! preg_match('/^([A-Za-z]+) identifier$/', (string) $parameter->getDescription(), $matches)) {
+            return $parameter;
+        }
+
+        $words = preg_split('/(?=[A-Z])/', preg_replace('/^Admin/', '', $matches[1]), -1, PREG_SPLIT_NO_EMPTY);
+
+        if (! $words) {
+            return $parameter;
+        }
+
+        $words = array_map('strtolower', $words);
+        $words[0] = ucfirst($words[0]);
+
+        return $parameter->withDescription(implode(' ', $words).' ID');
     }
 
     /**
@@ -473,7 +541,7 @@ class SplitOpenApiFactory implements OpenApiFactoryInterface
         }
 
         // Only include the example key if auto-inject is enabled for security
-        $playgroundKey = env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false) ? (env('STOREFRONT_PLAYGROUND_KEY') ?? 'pk_storefront_xxxxx') : '';
+        $playgroundKey = config('storefront.auto_inject_playground_key') ? (config('storefront.playground_key') ?: 'pk_storefront_xxxxx') : '';
 
         // Define all headers that should be present on every operation
         $headersToAdd = [

--- a/src/Providers/BagistoApiServiceProvider.php
+++ b/src/Providers/BagistoApiServiceProvider.php
@@ -46,7 +46,6 @@ use Webkul\BagistoApi\Admin\Audit\AdminApiAuditContext;
 use Webkul\BagistoApi\Admin\Audit\AdminApiAuditRecorder;
 use Webkul\BagistoApi\Admin\Auth\AdminApiGuard;
 use Webkul\BagistoApi\Admin\Metadata\NullableToOnePropertyMetadataFactory;
-use Webkul\BagistoApi\Metadata\SourceDocblockPropertyMetadataFactory;
 use Webkul\BagistoApi\Admin\Models\AdminPersonalAccessToken;
 use Webkul\BagistoApi\Admin\Resolver\AdminConfigurationMenuQueryResolver;
 use Webkul\BagistoApi\Admin\Resolver\AdminConfigurationSlugQueryResolver;
@@ -377,6 +376,7 @@ use Webkul\BagistoApi\Http\Middleware\SetAdminApiAuditContext;
 use Webkul\BagistoApi\Http\Middleware\SetLocaleChannel;
 use Webkul\BagistoApi\Http\Middleware\VerifyStorefrontKey;
 use Webkul\BagistoApi\Metadata\CustomIdentifiersExtractor;
+use Webkul\BagistoApi\Metadata\SourceDocblockPropertyMetadataFactory;
 use Webkul\BagistoApi\OpenApi\SplitOpenApiFactory;
 use Webkul\BagistoApi\Repositories\GuestCartTokensRepository;
 use Webkul\BagistoApi\Resolver\BaseQueryItemResolver;
@@ -1621,7 +1621,7 @@ class BagistoApiServiceProvider extends ServiceProvider
      */
     protected function isEuWithdrawalAvailable(): bool
     {
-        return class_exists(\Webkul\EUWithdrawal\Services\WithdrawalService::class);
+        return class_exists(WithdrawalService::class);
     }
 
     /**

--- a/src/Providers/BagistoApiServiceProvider.php
+++ b/src/Providers/BagistoApiServiceProvider.php
@@ -498,6 +498,11 @@ use Webkul\Sales\Repositories\RefundRepository;
 class BagistoApiServiceProvider extends ServiceProvider
 {
     /**
+     * Package version, surfaced as the OpenAPI `info.version`.
+     */
+    const BAGISTO_API_VERSION = '2.4.1';
+
+    /**
      * Register the service provider bindings.
      */
     public function register(): void

--- a/src/Providers/BagistoApiServiceProvider.php
+++ b/src/Providers/BagistoApiServiceProvider.php
@@ -574,7 +574,9 @@ class BagistoApiServiceProvider extends ServiceProvider
         // tokens (Bearer header → AdminApiGuard).
         $this->app->tag(AdminProfileProvider::class, ProviderInterface::class);
         $this->app->tag(CustomerReturnProvider::class, ProviderInterface::class);
-        $this->app->tag(EuWithdrawalProvider::class, ProviderInterface::class);
+        if ($this->isEuWithdrawalAvailable()) {
+            $this->app->tag(EuWithdrawalProvider::class, ProviderInterface::class);
+        }
         $this->app->tag(ReturnableItemProvider::class, ProviderInterface::class);
         $this->app->tag(ReturnReasonProvider::class, ProviderInterface::class);
         $this->app->tag(CustomerReturnMessageProvider::class, ProviderInterface::class);
@@ -652,10 +654,12 @@ class BagistoApiServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->tag(AdminEuWithdrawalCollectionProvider::class, ProviderInterface::class);
-        $this->app->tag(AdminEuWithdrawalItemProvider::class, ProviderInterface::class);
-        $this->app->tag(AdminEuWithdrawalWriteProvider::class, ProviderInterface::class);
-        $this->app->tag(AdminEuWithdrawalProcessor::class, ProcessorInterface::class);
+        if ($this->isEuWithdrawalAvailable()) {
+            $this->app->tag(AdminEuWithdrawalCollectionProvider::class, ProviderInterface::class);
+            $this->app->tag(AdminEuWithdrawalItemProvider::class, ProviderInterface::class);
+            $this->app->tag(AdminEuWithdrawalWriteProvider::class, ProviderInterface::class);
+            $this->app->tag(AdminEuWithdrawalProcessor::class, ProcessorInterface::class);
+        }
 
         $this->app->singleton(AdminReturnProcessor::class, function ($app) {
             return new AdminReturnProcessor(
@@ -672,7 +676,9 @@ class BagistoApiServiceProvider extends ServiceProvider
             );
         });
         $this->app->tag(CustomerReturnProcessor::class, ProcessorInterface::class);
-        $this->app->tag(EuWithdrawalProcessor::class, ProcessorInterface::class);
+        if ($this->isEuWithdrawalAvailable()) {
+            $this->app->tag(EuWithdrawalProcessor::class, ProcessorInterface::class);
+        }
         $this->app->tag(CustomerReturnMessageProcessor::class, ProcessorInterface::class);
         $this->app->tag(OrderCollectionProvider::class, ProviderInterface::class);
         $this->app->tag(OrderDetailProvider::class, ProviderInterface::class);
@@ -1117,13 +1123,15 @@ class BagistoApiServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton(EuWithdrawalProcessor::class, function ($app) {
-            return new EuWithdrawalProcessor(
-                $app->make(PersistProcessor::class),
-                $app->make(OrderRepository::class),
-                $app->make(WithdrawalService::class),
-            );
-        });
+        if ($this->isEuWithdrawalAvailable()) {
+            $this->app->singleton(EuWithdrawalProcessor::class, function ($app) {
+                return new EuWithdrawalProcessor(
+                    $app->make(PersistProcessor::class),
+                    $app->make(OrderRepository::class),
+                    $app->make(WithdrawalService::class),
+                );
+            });
+        }
 
         $this->app->singleton(CustomerReturnMessageProcessor::class, function ($app) {
             return new CustomerReturnMessageProcessor(
@@ -1597,6 +1605,15 @@ class BagistoApiServiceProvider extends ServiceProvider
     {
         if ($this->app->bound('api_platform.metadata_factory')) {
         }
+    }
+
+    /**
+     * Whether the core EU Withdrawal module is installed (Bagisto >= 2.4.5).
+     * Its resources/state depend on Webkul\EUWithdrawal\*, absent on older cores.
+     */
+    protected function isEuWithdrawalAvailable(): bool
+    {
+        return class_exists(\Webkul\EUWithdrawal\Services\WithdrawalService::class);
     }
 
     /**

--- a/src/Providers/BagistoApiServiceProvider.php
+++ b/src/Providers/BagistoApiServiceProvider.php
@@ -46,6 +46,7 @@ use Webkul\BagistoApi\Admin\Audit\AdminApiAuditContext;
 use Webkul\BagistoApi\Admin\Audit\AdminApiAuditRecorder;
 use Webkul\BagistoApi\Admin\Auth\AdminApiGuard;
 use Webkul\BagistoApi\Admin\Metadata\NullableToOnePropertyMetadataFactory;
+use Webkul\BagistoApi\Metadata\SourceDocblockPropertyMetadataFactory;
 use Webkul\BagistoApi\Admin\Models\AdminPersonalAccessToken;
 use Webkul\BagistoApi\Admin\Resolver\AdminConfigurationMenuQueryResolver;
 use Webkul\BagistoApi\Admin\Resolver\AdminConfigurationSlugQueryResolver;
@@ -536,6 +537,13 @@ class BagistoApiServiceProvider extends ServiceProvider
             PropertyMetadataFactoryInterface::class,
             function ($decorated) {
                 return new NullableToOnePropertyMetadataFactory($decorated);
+            }
+        );
+
+        $this->app->extend(
+            PropertyMetadataFactoryInterface::class,
+            function ($decorated) {
+                return new SourceDocblockPropertyMetadataFactory($decorated);
             }
         );
 

--- a/src/Resolver/Factory/ProductRelationResolverFactory.php
+++ b/src/Resolver/Factory/ProductRelationResolverFactory.php
@@ -289,7 +289,7 @@ class ProductRelationResolverFactory implements ResolverFactoryInterface
                                 if ($modelClass === 'Product') {
                                     $node['id'] = '/api/shop/products/'.$item->id;
                                     $node['sku'] = $item->sku;
-                                    $node['baseImageUrl'] = env('API_URL').$item->getBaseImageUrlAttribute();
+                                    $node['baseImageUrl'] = $item->getBaseImageUrlAttribute();
 
                                 } elseif ($modelClass === 'BookingProduct') {
                                     $node['id'] = '/api/shop/booking-products/'.$item->id;

--- a/src/Resources/lang/en/app.php
+++ b/src/Resources/lang/en/app.php
@@ -611,7 +611,7 @@ return [
         'reporting' => [
             'invalid-entity' => 'Unknown reporting entity.',
             'invalid-type' => 'Unknown reporting stat type for this entity.',
-            'export-format-unsupported' => 'Only the csv export format is supported.',
+            'export-format-unsupported' => 'Only the csv, xls and xlsx export formats are supported.',
         ],
 
         'configuration' => [
@@ -781,7 +781,7 @@ return [
             'refund' => [
                 'not-found' => 'Refund not found.',
                 'no-permission' => 'You do not have permission to view refunds.',
-                'export-format-unsupported' => 'Only csv export is currently supported.',
+                'export-format-unsupported' => 'Only csv, xls and xlsx exports are supported.',
             ],
             'transaction' => [
                 'not-found' => 'Transaction not found.',
@@ -801,7 +801,7 @@ return [
                 'no-permission' => 'You do not have permission to view bookings.',
             ],
             'export' => [
-                'format-unsupported' => 'Only csv export is currently supported.',
+                'format-unsupported' => 'Only csv, xls and xlsx exports are supported.',
             ],
         ],
 

--- a/src/State/CheckoutAddressProvider.php
+++ b/src/State/CheckoutAddressProvider.php
@@ -10,12 +10,15 @@ use Webkul\BagistoApi\Exception\AuthenticationException;
 use Webkul\BagistoApi\Exception\ResourceNotFoundException;
 use Webkul\BagistoApi\Facades\CartTokenFacade;
 use Webkul\BagistoApi\Facades\TokenHeaderFacade;
+use Webkul\BagistoApi\State\Concerns\ResolvesCartToken;
 
 /**
  * Provides address data from BagistoApi queries.
  */
 class CheckoutAddressProvider implements ProviderInterface
 {
+    use ResolvesCartToken;
+
     public function __construct() {}
 
     /**
@@ -52,7 +55,7 @@ class CheckoutAddressProvider implements ProviderInterface
         $output = new CheckoutAddressOutput;
 
         $output->id = $cart->id;
-        $output->cartToken = $cart->guest_cart_token ?? $cart->customer_id;
+        $output->cartToken = $this->resolveCartToken($cart);
         $output->customerId = $cart->customer_id;
 
         $billingAddress = $cart->billing_address;

--- a/src/State/CheckoutProcessor.php
+++ b/src/State/CheckoutProcessor.php
@@ -18,10 +18,12 @@ use Webkul\BagistoApi\Facades\TokenHeaderFacade;
 use Webkul\BagistoApi\Models\CheckoutOrder;
 use Webkul\BagistoApi\Models\CheckoutPaymentMethod;
 use Webkul\BagistoApi\Models\CheckoutShippingMethod;
+use Webkul\BagistoApi\State\Concerns\ResolvesCartToken;
 use Webkul\Checkout\Facades\Cart;
 use Webkul\Checkout\Models\CartAddress;
 use Webkul\Checkout\Repositories\CartRepository;
 use Webkul\Customer\Repositories\CustomerRepository;
+use Webkul\Payment\Facades\Payment;
 use Webkul\Sales\Repositories\OrderRepository;
 use Webkul\Sales\Transformers\OrderResource;
 use Webkul\Shipping\Facades\Shipping;
@@ -31,6 +33,8 @@ use Webkul\Shipping\Facades\Shipping;
  */
 class CheckoutProcessor implements ProcessorInterface
 {
+    use ResolvesCartToken;
+
     public function __construct(
         protected CustomerRepository $customerRepository,
         protected OrderRepository $orderRepository,
@@ -242,7 +246,7 @@ class CheckoutProcessor implements ProcessorInterface
                 'id' => (string) $cart->id,
                 'success' => true,
                 'message' => __('bagistoapi::app.graphql.checkout.shipping-method-saved'),
-                'cartToken' => (string) ($cart->guest_cart_token ?? $cart->customer_id),
+                'cartToken' => $this->resolveCartToken($cart),
                 'shippingMethod' => (string) ($cart->shipping_method ?? ''),
             ]);
         } catch (\Exception $e) {
@@ -280,7 +284,10 @@ class CheckoutProcessor implements ProcessorInterface
             if ($cart->payment) {
                 $paymentMethodClass = app($paymentMethodConfig['class']);
 
-                if (method_exists($paymentMethodClass, 'getPaymentUrl') && method_exists($paymentMethodClass, 'getPaymentData')) {
+                if (
+                    is_callable([$paymentMethodClass, 'getPaymentUrl'])
+                    && is_callable([$paymentMethodClass, 'getPaymentData'])
+                ) {
                     $paymentData = $paymentMethodClass->getPaymentData($cart);
 
                     if ($input->paymentSuccessUrl) {
@@ -308,13 +315,15 @@ class CheckoutProcessor implements ProcessorInterface
 
                     $paymentGatewayUrl = $paymentMethodClass->getPaymentUrl();
                     $paymentData = json_encode($paymentData);
+                } else {
+                    $paymentGatewayUrl = Payment::getRedirectUrl($cart) ?: null;
                 }
             }
 
             return $this->paymentMethodOutput([
                 'success' => true,
                 'message' => __('bagistoapi::app.graphql.checkout.payment-method-saved'),
-                'cartToken' => (string) ($cart->guest_cart_token ?? $cart->customer_id),
+                'cartToken' => $this->resolveCartToken($cart),
                 'paymentMethod' => (string) ($cart->payment?->method ?? ''),
                 'paymentGatewayUrl' => $paymentGatewayUrl,
                 'paymentData' => $paymentData,
@@ -334,6 +343,17 @@ class CheckoutProcessor implements ProcessorInterface
 
             Cart::setCart($cart);
             Cart::collectTotals();
+
+            $cart = Cart::getCart();
+
+            if ($redirectUrl = Payment::getRedirectUrl($cart)) {
+                return $this->orderOutput([
+                    'id' => $cart->id,
+                    'cartToken' => $this->resolveCartToken($cart),
+                    'redirect' => true,
+                    'redirectUrl' => $redirectUrl,
+                ]);
+            }
 
             $orderData = $this->buildOrderDataFromCart($cart);
             $order = $this->orderRepository->create($orderData);
@@ -356,8 +376,10 @@ class CheckoutProcessor implements ProcessorInterface
 
             return $this->orderOutput([
                 'id' => $cart->id,
-                'cartToken' => (string) ($cart->guest_cart_token ?? $cart->customer_id),
+                'cartToken' => $this->resolveCartToken($cart),
                 'orderId' => (string) $order->id,
+                'redirect' => false,
+                'redirectUrl' => null,
             ]);
         } catch (\Exception $e) {
             throw new OperationFailedException($e->getMessage(), 0, $e);
@@ -492,7 +514,7 @@ class CheckoutProcessor implements ProcessorInterface
 
         if ($billingAddress) {
             $output->id = $billingAddress->id;
-            $output->cartToken = (string) ($billingAddress->cart->guest_cart_token ?? $billingAddress->cart->customer_id);
+            $output->cartToken = $this->resolveCartToken($billingAddress->cart);
             $output->customerId = $billingAddress->cart->customer_id;
 
             $output->billingFirstName = (string) ($billingAddress->first_name ?? '');
@@ -532,7 +554,7 @@ class CheckoutProcessor implements ProcessorInterface
             $output = new CheckoutAddressOutput;
 
             $output->id = $cart->id;
-            $output->cartToken = $cart->guest_cart_token ?? $cart->customer_id;
+            $output->cartToken = $this->resolveCartToken($cart);
             $output->customerId = $cart->customer_id;
 
             $billingAddress = $cart->billing_address;

--- a/src/State/Concerns/ResolvesCartToken.php
+++ b/src/State/Concerns/ResolvesCartToken.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webkul\BagistoApi\State\Concerns;
+
+use Webkul\BagistoApi\Models\GuestCartTokens;
+
+trait ResolvesCartToken
+{
+    /**
+     * Resolve the guest cart token issued for this cart. Null for a customer-owned cart,
+     * which is addressed by the customer's bearer token instead.
+     */
+    protected function resolveCartToken($cart): ?string
+    {
+        if (empty($cart?->id)) {
+            return null;
+        }
+
+        return GuestCartTokens::where('cart_id', $cart->id)->orderByDesc('id')->value('token');
+    }
+}

--- a/src/State/CustomizableOptionFileProcessor.php
+++ b/src/State/CustomizableOptionFileProcessor.php
@@ -39,14 +39,14 @@ class CustomizableOptionFileProcessor implements ProcessorInterface
             throw new InvalidInputException(__('bagistoapi::app.graphql.cart.customizable-file-option-invalid'));
         }
 
-        $cfg = $this->staging->config();
         $allowed = $this->allowedExtensions($option->supported_file_extensions);
         $ext = strtolower($file?->getClientOriginalExtension() ?? '');
+        $maxBytes = $this->staging->maxUploadBytes();
 
         if (
             ! $file
             || ($allowed && ! in_array($ext, $allowed, true))
-            || $file->getSize() > ((int) $cfg['max_size_kb'] * 1024)
+            || ($maxBytes > 0 && $file->getSize() > $maxBytes)
         ) {
             throw new InvalidInputException(__('bagistoapi::app.graphql.cart.customizable-file-invalid'));
         }

--- a/src/State/ProductDetailProvider.php
+++ b/src/State/ProductDetailProvider.php
@@ -131,7 +131,7 @@ class ProductDetailProvider implements ProviderInterface
                 path: $img->path,
                 product_id: (int) $img->product_id,
                 position: $img->position !== null ? (int) $img->position : null,
-                public_path: env('API_URL').($img->url ?? ''),
+                public_path: $img->url ?? '',
             ))->values()->all();
 
         $dto->videos = $product->videos
@@ -141,7 +141,7 @@ class ProductDetailProvider implements ProviderInterface
                 path: $vid->path,
                 product_id: (int) $vid->product_id,
                 position: $vid->position !== null ? (int) $vid->position : null,
-                public_path: env('API_URL').($vid->url ?? ''),
+                public_path: $vid->url ?? '',
             ))->values()->all();
 
         // Super attributes + variants (configurable only)

--- a/src/Support/CartOptionFileStaging.php
+++ b/src/Support/CartOptionFileStaging.php
@@ -9,14 +9,34 @@ use Illuminate\Support\Str;
 
 class CartOptionFileStaging
 {
-    public function config(): array
+    /** Disk and directory the staged uploads live on. */
+    public const DISK = 'private';
+
+    public const STAGE_DIR = 'cart-uploads';
+
+    /** How long a staged upload stays resolvable — follows the store's session lifetime. */
+    public function ttlMinutes(): int
     {
-        return config('storefront.cart.customizable_file', [
-            'max_size_kb' => 2048,
-            'ttl_minutes' => 60,
-            'disk' => 'private',
-            'stage_dir' => 'cart-uploads',
-        ]);
+        return (int) config('session.lifetime', 120);
+    }
+
+    /** Upload ceiling, taken from php.ini (`upload_max_filesize`) like the rest of Bagisto. */
+    public function maxUploadBytes(): int
+    {
+        $limit = trim((string) core()->getMaxUploadSize());
+
+        if ($limit === '') {
+            return 0;
+        }
+
+        $value = (int) $limit;
+
+        return match (strtoupper(substr($limit, -1))) {
+            'G' => $value * 1024 ** 3,
+            'M' => $value * 1024 ** 2,
+            'K' => $value * 1024,
+            default => $value,
+        };
     }
 
     public function cartOptionFileKey(string $token): string
@@ -26,10 +46,9 @@ class CartOptionFileStaging
 
     public function stage(UploadedFile $file, int $productId, int $optionId, int|string $ownerId): array
     {
-        $cfg = $this->config();
         $ext = strtolower($file->getClientOriginalExtension() ?: ($file->extension() ?: 'bin'));
         $name = Str::random(40).'.'.$ext;
-        $path = $file->storeAs($cfg['stage_dir'], $name, $cfg['disk']);
+        $path = $file->storeAs(self::STAGE_DIR, $name, self::DISK);
 
         $token = Str::random(48);
 
@@ -40,7 +59,7 @@ class CartOptionFileStaging
             'product_id' => $productId,
             'option_id' => $optionId,
             'owner_id' => (string) $ownerId,
-        ], now()->addMinutes((int) $cfg['ttl_minutes']));
+        ], now()->addMinutes($this->ttlMinutes()));
 
         return ['token' => $token, 'fileName' => $file->getClientOriginalName()];
     }
@@ -57,16 +76,14 @@ class CartOptionFileStaging
 
     public function deleteStaged(string $path): void
     {
-        $disk = $this->config()['disk'];
-
-        if (Storage::disk($disk)->exists($path)) {
-            Storage::disk($disk)->delete($path);
+        if (Storage::disk(self::DISK)->exists($path)) {
+            Storage::disk(self::DISK)->delete($path);
         }
     }
 
     public function stagedUploadedFile(array $payload): UploadedFile
     {
-        $absolute = Storage::disk($this->config()['disk'])->path($payload['path']);
+        $absolute = Storage::disk(self::DISK)->path($payload['path']);
 
         return new UploadedFile($absolute, $payload['original_name'], $payload['mime'], null, true);
     }

--- a/src/resources/views/api-platform/swagger-ui-embedded.blade.php
+++ b/src/resources/views/api-platform/swagger-ui-embedded.blade.php
@@ -146,7 +146,7 @@
         @if(isset($endpoint) && $endpoint === 'shop')
         <div class="storefront-key-notice">
             <strong>🔐 Authentication:</strong> This API requires the <strong>X-STOREFRONT-KEY</strong> header.
-            @if(env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+            @if(config('storefront.auto_inject_playground_key'))
             The key is automatically included in requests from this documentation page.
             @else
             You can manually enter your key in the Authorize button above.
@@ -186,7 +186,7 @@
                 const specData = specDataElement ? JSON.parse(specDataElement.textContent) : {};
 
                 
-                @if(isset($endpoint) && $endpoint === 'shop' && !env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                @if(isset($endpoint) && $endpoint === 'shop' && !config('storefront.auto_inject_playground_key'))
                 
                 Object.keys(sessionStorage).forEach(key => {
                     if (key.includes('swagger') || key.includes('auth') || key.includes('X-STOREFRONT')) {
@@ -205,7 +205,7 @@
                     spec: specData,
                     dom_id: '#swagger-ui',
                     validatorUrl: null,
-                    persistAuthorization: @if(isset($endpoint) && $endpoint === 'admin') true @elseif(isset($endpoint) && $endpoint === 'shop' && env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false)) true @else false @endif,
+                    persistAuthorization: @if(isset($endpoint) && $endpoint === 'admin') true @elseif(isset($endpoint) && $endpoint === 'shop' && config('storefront.auto_inject_playground_key')) true @else false @endif,
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -229,8 +229,8 @@
                     showRequestHeaders: true,
                     supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'],
                     requestInterceptor: function(request) {
-                        @if(isset($endpoint) && $endpoint === 'shop' && env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
-                        const storefrontKey = "{{ env('STOREFRONT_PLAYGROUND_KEY') ?? 'pk_storefront_xxxxx' }}";
+                        @if(isset($endpoint) && $endpoint === 'shop' && config('storefront.auto_inject_playground_key'))
+                        const storefrontKey = "{{ config('storefront.playground_key') ?: 'pk_storefront_xxxxx' }}";
                         if (storefrontKey && !request.url.includes('/api/admin')) {
                             request.headers['X-STOREFRONT-KEY'] = storefrontKey;
                         }
@@ -252,7 +252,7 @@
                             }
                         }
                         
-                        @if(isset($endpoint) && $endpoint === 'shop' && !env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                        @if(isset($endpoint) && $endpoint === 'shop' && !config('storefront.auto_inject_playground_key'))
                             if (window.ui && window.ui.preauthorizeApiKey) {
                                 window.ui.preauthorizeApiKey('X-STOREFRONT-KEY', '');
                             }
@@ -260,7 +260,7 @@
                     };
                 @else
                     config.onComplete = function() {
-                        @if(isset($endpoint) && $endpoint === 'shop' && !env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                        @if(isset($endpoint) && $endpoint === 'shop' && !config('storefront.auto_inject_playground_key'))
                         if (window.ui && window.ui.preauthorizeApiKey) {
                             window.ui.preauthorizeApiKey('X-STOREFRONT-KEY', '');
                         }

--- a/src/resources/views/api-platform/swagger-ui.blade.php
+++ b/src/resources/views/api-platform/swagger-ui.blade.php
@@ -76,7 +76,7 @@
         <script>
             window.onload = function() {
                 
-                @if(isset($endpoint) && $endpoint === 'shop' && !env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                @if(isset($endpoint) && $endpoint === 'shop' && !config('storefront.auto_inject_playground_key'))
                 
                 Object.keys(sessionStorage).forEach(key => {
                     if (key.includes('swagger') || key.includes('auth') || key.includes('X-STOREFRONT')) {
@@ -95,7 +95,7 @@
                     url: "{{ $specUrl }}",
                     dom_id: '#swagger-ui',
                     validatorUrl: null,
-                    persistAuthorization: @if(isset($endpoint) && $endpoint === 'admin') true @elseif(isset($endpoint) && $endpoint === 'shop' && env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false)) true @else false @endif,
+                    persistAuthorization: @if(isset($endpoint) && $endpoint === 'admin') true @elseif(isset($endpoint) && $endpoint === 'shop' && config('storefront.auto_inject_playground_key')) true @else false @endif,
                     presets: [
                         SwaggerUIBundle.presets.apis,
                         SwaggerUIStandalonePreset
@@ -123,9 +123,9 @@
                             request.headers['Accept'] = 'application/vnd.openapi+json';
                         }
                         
-                        @if(isset($endpoint) && $endpoint === 'shop' && env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                        @if(isset($endpoint) && $endpoint === 'shop' && config('storefront.auto_inject_playground_key'))
                         if (!request.url.includes('/api/admin')) {
-                            const storefrontKey = "{{ env('STOREFRONT_PLAYGROUND_KEY') ?? config('storefront.playground_key') }}";
+                            const storefrontKey = "{{ config('storefront.playground_key') }}";
                             if (storefrontKey) {
                                 request.headers['X-STOREFRONT-KEY'] = storefrontKey;
                             }
@@ -151,7 +151,7 @@
                     }
                     
                     
-                    @if(isset($endpoint) && $endpoint === 'shop' && !env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                    @if(isset($endpoint) && $endpoint === 'shop' && !config('storefront.auto_inject_playground_key'))
                     if (window.ui && window.ui.preauthorizeApiKey) {
                         window.ui.preauthorizeApiKey('X-STOREFRONT-KEY', '');
                     }
@@ -160,7 +160,7 @@
                 @else
                 
                 config.onComplete = function() {
-                    @if(isset($endpoint) && $endpoint === 'shop' && !env('API_PLAYGROUND_AUTO_INJECT_STOREFRONT_KEY', false))
+                    @if(isset($endpoint) && $endpoint === 'shop' && !config('storefront.auto_inject_playground_key'))
                     if (window.ui && window.ui.preauthorizeApiKey) {
                         window.ui.preauthorizeApiKey('X-STOREFRONT-KEY', '');
                     }

--- a/tests/Feature/Admin/RestApi/CatalogProductTest.php
+++ b/tests/Feature/Admin/RestApi/CatalogProductTest.php
@@ -1382,10 +1382,25 @@ class CatalogProductTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,Name,SKU,"Attribute Family",Price,Quantity,Status,Category,Type');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/catalog/products/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/catalog/products/export?format=xlsx', array_merge(
+        $this->get('/api/admin/catalog/products/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/CmsPageTest.php
+++ b/tests/Feature/Admin/RestApi/CmsPageTest.php
@@ -617,10 +617,25 @@ class CmsPageTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,"Page Title","URL Key",Channel,Locale');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/cms/pages/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/cms/pages/export?format=xlsx', array_merge(
+        $this->get('/api/admin/cms/pages/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/OrderTest.php
+++ b/tests/Feature/Admin/RestApi/OrderTest.php
@@ -219,10 +219,25 @@ class OrderTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,Status,"Grand Total","Payment Method",Channel,Customer,Email,"Order Date"');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/orders/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/orders/export?format=xlsx', array_merge(
+        $this->get('/api/admin/orders/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/ReportingTest.php
+++ b/tests/Feature/Admin/RestApi/ReportingTest.php
@@ -308,10 +308,25 @@ class ReportingTest extends AdminApiTestCase
         expect($response->headers->get('Content-Type'))->toContain('text/csv');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/reporting/sales/export?type=total-sales&format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/reporting/sales/export?type=total-sales&format=xlsx', array_merge(
+        $this->get('/api/admin/reporting/sales/export?type=total-sales&format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/SalesBookingsTest.php
+++ b/tests/Feature/Admin/RestApi/SalesBookingsTest.php
@@ -104,10 +104,25 @@ class SalesBookingsTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,"Order ID",Qty,From,To,"Booking Date"');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/bookings/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/bookings/export?format=xlsx', array_merge(
+        $this->get('/api/admin/bookings/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/SalesInvoicesListTest.php
+++ b/tests/Feature/Admin/RestApi/SalesInvoicesListTest.php
@@ -110,10 +110,25 @@ class SalesInvoicesListTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,"Order ID",Status,"Grand Total","Invoice Date"');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/invoices/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/invoices/export?format=xlsx', array_merge(
+        $this->get('/api/admin/invoices/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/SalesRefundsListTest.php
+++ b/tests/Feature/Admin/RestApi/SalesRefundsListTest.php
@@ -91,10 +91,25 @@ class SalesRefundsListTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,"Order ID","Refunded Amount","Billed To","Refund Date"');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/refunds/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/refunds/export?format=xlsx', array_merge(
+        $this->get('/api/admin/refunds/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/SalesShipmentsListTest.php
+++ b/tests/Feature/Admin/RestApi/SalesShipmentsListTest.php
@@ -96,10 +96,25 @@ class SalesShipmentsListTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,"Order ID","Total Qty","Inventory Source","Shipped To","Shipment Date"');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/shipments/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/shipments/export?format=xlsx', array_merge(
+        $this->get('/api/admin/shipments/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/SalesTransactionsTest.php
+++ b/tests/Feature/Admin/RestApi/SalesTransactionsTest.php
@@ -147,10 +147,25 @@ class SalesTransactionsTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,"Transaction ID","Invoice ID","Order ID",Status,Date');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/transactions/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/transactions/export?format=xlsx', array_merge(
+        $this->get('/api/admin/transactions/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/Admin/RestApi/SettingsTaxRateTest.php
+++ b/tests/Feature/Admin/RestApi/SettingsTaxRateTest.php
@@ -436,10 +436,25 @@ class SettingsTaxRateTest extends AdminApiTestCase
         expect($response->getContent())->toContain('ID,Identifier,State,Country');
     }
 
+    public function test_export_supports_xlsx(): void
+    {
+        $admin = $this->createAdmin();
+
+        $response = $this->get('/api/admin/settings/tax-rates/export?format=xlsx', array_merge(
+            $this->adminHeaders($admin),
+            ['Accept' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+        ));
+
+        $response->assertStatus(200);
+
+        expect($response->headers->get('Content-Type'))->toContain('spreadsheetml');
+        expect($response->headers->get('Content-Disposition'))->toContain('.xlsx');
+    }
+
     public function test_export_unsupported_format_returns_422(): void
     {
         $admin = $this->createAdmin();
-        $this->get('/api/admin/settings/tax-rates/export?format=xlsx', array_merge(
+        $this->get('/api/admin/settings/tax-rates/export?format=pdf', array_merge(
             $this->adminHeaders($admin),
             ['Accept' => 'text/csv'],
         ))->assertStatus(422);

--- a/tests/Feature/GraphQL/CustomerCheckoutTest.php
+++ b/tests/Feature/GraphQL/CustomerCheckoutTest.php
@@ -3,6 +3,7 @@
 namespace Webkul\BagistoApi\Tests\Feature\GraphQL;
 
 use Webkul\BagistoApi\Tests\GraphQLTestCase;
+use Webkul\Sales\Models\Order;
 
 class CustomerCheckoutTest extends GraphQLTestCase
 {
@@ -816,6 +817,77 @@ class CustomerCheckoutTest extends GraphQLTestCase
     /**
      * Helper to set checkout address
      */
+    public function test_payment_method_resolves_a_gateway_url_for_a_redirect_gateway(): void
+    {
+        $customerData = $this->createTestCustomer();
+        $token = $customerData['token'];
+
+        $this->addProductToCart($token);
+        $this->setCheckoutAddress($token);
+        $this->setShippingMethod($token);
+
+        $query = <<<'GQL'
+            mutation createCheckoutPaymentMethod($paymentMethod: String!) {
+              createCheckoutPaymentMethod(input: {paymentMethod: $paymentMethod}) {
+                checkoutPaymentMethod {
+                  success
+                  paymentGatewayUrl
+                }
+              }
+            }
+        GQL;
+
+        $response = $this->graphQL($query, ['paymentMethod' => 'stripe'], $this->customerHeaders($token));
+
+        $response->assertSuccessful();
+
+        $this->assertNull($response->json('errors'));
+
+        $data = $response->json('data.createCheckoutPaymentMethod.checkoutPaymentMethod');
+
+        $this->assertTrue($data['success']);
+        $this->assertStringContainsString('/stripe/redirect', (string) $data['paymentGatewayUrl']);
+    }
+
+    public function test_place_order_returns_a_redirect_and_creates_no_order_for_a_redirect_gateway(): void
+    {
+        $customerData = $this->createTestCustomer();
+        $token = $customerData['token'];
+
+        $this->addProductToCart($token);
+        $this->setCheckoutAddress($token);
+        $this->setShippingMethod($token);
+        $this->setPaymentMethod($token, 'stripe');
+
+        $ordersBefore = Order::count();
+
+        $query = <<<'GQL'
+            mutation createCheckoutOrder {
+              createCheckoutOrder(input:{}) {
+                checkoutOrder {
+                  orderId
+                  redirect
+                  redirectUrl
+                }
+              }
+            }
+        GQL;
+
+        $response = $this->graphQL($query, [], $this->customerHeaders($token));
+
+        $response->assertSuccessful();
+
+        $this->assertNull($response->json('errors'));
+
+        $data = $response->json('data.createCheckoutOrder.checkoutOrder');
+
+        $this->assertTrue($data['redirect']);
+        $this->assertStringContainsString('/stripe/redirect', (string) $data['redirectUrl']);
+        $this->assertNull($data['orderId']);
+
+        $this->assertSame($ordersBefore, Order::count());
+    }
+
     private function setCheckoutAddress(string $token): void
     {
         $headers = $this->customerHeaders($token);
@@ -909,7 +981,7 @@ class CustomerCheckoutTest extends GraphQLTestCase
     /**
      * Helper to set payment method
      */
-    private function setPaymentMethod(string $token): void
+    private function setPaymentMethod(string $token, string $method = 'moneytransfer'): void
     {
         $headers = $this->customerHeaders($token);
 
@@ -936,7 +1008,7 @@ class CustomerCheckoutTest extends GraphQLTestCase
         GQL;
 
         $variables = [
-            'paymentMethod' => 'moneytransfer',
+            'paymentMethod' => $method,
             'successUrl' => 'https://myapp.com/payment/success',
             'failureUrl' => 'https://myapp.com/payment/failure',
             'cancelUrl' => 'https://myapp.com/payment/cancel',

--- a/tests/Feature/GraphQL/GuestCartTest.php
+++ b/tests/Feature/GraphQL/GuestCartTest.php
@@ -630,6 +630,29 @@ class GuestCartTest extends GraphQLTestCase
         $this->assertSame($code, $read->json('data.createReadCart.readCart.couponCode'));
     }
 
+    public function test_read_cart_returns_the_issued_guest_token_not_the_cart_id(): void
+    {
+        $token = $this->getGuestCartToken();
+        $headers = $this->guestHeaders($token);
+
+        $productData = $this->createTestProduct();
+
+        $add = $this->graphQL(<<<'GQL'
+            mutation add($productId: Int!, $quantity: Int!) {
+              createAddProductInCart(input: {productId: $productId, quantity: $quantity}) {
+                addProductInCart { id cartToken }
+              }
+            }
+        GQL, ['productId' => $productData['product']->id, 'quantity' => 1], $headers);
+
+        $add->assertSuccessful();
+
+        $cart = $add->json('data.createAddProductInCart.addProductInCart');
+
+        $this->assertSame($token, $cart['cartToken']);
+        $this->assertNotSame((string) $cart['id'], $cart['cartToken']);
+    }
+
     public function test_remove_coupon_response_carries_success_and_message_graphql(): void
     {
         $code = $this->seedActiveCoupon();

--- a/tests/Feature/GraphQL/GuestCheckoutTest.php
+++ b/tests/Feature/GraphQL/GuestCheckoutTest.php
@@ -247,6 +247,48 @@ class GuestCheckoutTest extends GraphQLTestCase
         $this->assertArrayHasKey('success', $data);
     }
 
+    public function test_checkout_address_returns_the_real_guest_cart_token(): void
+    {
+        $token = $this->getGuestCartToken();
+
+        $this->addProductToCart($token);
+
+        $query = <<<'GQL'
+            mutation createCheckoutAddress {
+              createCheckoutAddress(
+                input: {
+                  billingFirstName: "John"
+                  billingLastName: "Doe"
+                  billingEmail: "john@example.com"
+                  billingAddress: "123 Main St"
+                  billingCity: "Los Angeles"
+                  billingCountry: "IN"
+                  billingState: "UP"
+                  billingPostcode: "201301"
+                  billingPhoneNumber: "2125551234"
+                  useForShipping: true
+                }
+              ) {
+                checkoutAddress {
+                  success
+                  cartToken
+                }
+              }
+            }
+        GQL;
+
+        $response = $this->graphQL($query, [], $this->guestHeaders($token));
+
+        $response->assertSuccessful();
+
+        $this->assertNull($response->json('errors'));
+
+        $data = $response->json('data.createCheckoutAddress.checkoutAddress');
+
+        $this->assertTrue($data['success']);
+        $this->assertSame($token, $data['cartToken']);
+    }
+
     /**
      * Set Shipping Method (Guest)
      */

--- a/tests/Feature/RestApi/CheckoutAddressTest.php
+++ b/tests/Feature/RestApi/CheckoutAddressTest.php
@@ -2,11 +2,20 @@
 
 namespace Webkul\BagistoApi\Tests\Feature\RestApi;
 
+use Illuminate\Testing\TestResponse;
 use Webkul\BagistoApi\Tests\RestApiTestCase;
 use Webkul\Checkout\Models\CartAddress;
 
 class CheckoutAddressTest extends RestApiTestCase
 {
+    private function guestPostWithToken(string $url, string $token, array $payload): TestResponse
+    {
+        return $this->withHeaders([
+            ...$this->storefrontHeaders(),
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson($url, $payload);
+    }
+
     /**
      * Add product to customer's cart via REST so we have an active cart to set addresses on.
      */
@@ -20,6 +29,70 @@ class CheckoutAddressTest extends RestApiTestCase
         ]);
 
         $response->assertSuccessful();
+    }
+
+    public function test_address_response_returns_the_real_guest_cart_token(): void
+    {
+        $this->seedRequiredData();
+
+        $tokenResponse = $this->publicPost('/api/shop/cart-tokens', ['createNew' => true]);
+
+        expect($tokenResponse->getStatusCode())->toBeIn([200, 201]);
+
+        $cartToken = $tokenResponse->json('cartToken') ?? $tokenResponse->json('sessionToken');
+
+        $this->assertNotEmpty($cartToken);
+
+        $product = $this->createTestProduct()['product'];
+
+        $this->guestPostWithToken('/api/shop/add-product-in-cart', $cartToken, [
+            'productId' => $product->id,
+            'quantity' => 1,
+        ])->assertSuccessful();
+
+        $response = $this->guestPostWithToken('/api/shop/checkout-addresses', $cartToken, [
+            'billingFirstName' => 'John',
+            'billingLastName' => 'Doe',
+            'billingEmail' => 'john@example.com',
+            'billingAddress' => '123 Main St',
+            'billingCity' => 'Los Angeles',
+            'billingCountry' => 'IN',
+            'billingState' => 'UP',
+            'billingPostcode' => '201301',
+            'billingPhoneNumber' => '2125551234',
+            'useForShipping' => true,
+        ]);
+
+        $response->assertCreated();
+
+        expect($response->json('cartToken'))->toBe($cartToken);
+    }
+
+    public function test_address_response_returns_no_cart_token_for_a_customer_cart(): void
+    {
+        $this->seedRequiredData();
+        $customer = $this->createCustomer([
+            'token' => md5(uniqid((string) rand(), true)),
+        ]);
+        $this->addProductToCart($customer);
+
+        $response = $this->authenticatedPost($customer, '/api/shop/checkout-addresses', [
+            'billingFirstName' => 'John',
+            'billingLastName' => 'Doe',
+            'billingEmail' => 'john@example.com',
+            'billingAddress' => '123 Main St',
+            'billingCity' => 'Los Angeles',
+            'billingCountry' => 'IN',
+            'billingState' => 'UP',
+            'billingPostcode' => '201301',
+            'billingPhoneNumber' => '2125551234',
+            'useForShipping' => true,
+        ]);
+
+        $response->assertCreated();
+
+        expect($response->json('cartToken'))->toBeNull();
+        expect($response->json('cartToken'))->not->toBe((string) $customer->id);
     }
 
     public function test_set_checkout_address_with_use_for_shipping(): void

--- a/tests/Feature/RestApi/CheckoutOrderTest.php
+++ b/tests/Feature/RestApi/CheckoutOrderTest.php
@@ -4,6 +4,7 @@ namespace Webkul\BagistoApi\Tests\Feature\RestApi;
 
 use Webkul\BagistoApi\Tests\RestApiTestCase;
 use Webkul\Customer\Models\Customer;
+use Webkul\Sales\Models\Order;
 
 class CheckoutOrderTest extends RestApiTestCase
 {
@@ -51,10 +52,10 @@ class CheckoutOrderTest extends RestApiTestCase
         ])->assertCreated();
     }
 
-    private function setPaymentMethod(Customer $customer): void
+    private function setPaymentMethod(Customer $customer, string $method = 'cashondelivery'): void
     {
         $this->authenticatedPost($customer, '/api/shop/checkout-payment-methods', [
-            'paymentMethod' => 'cashondelivery',
+            'paymentMethod' => $method,
         ])->assertCreated();
     }
 
@@ -95,5 +96,49 @@ class CheckoutOrderTest extends RestApiTestCase
             $json = $response->json();
             expect($json)->toBeArray();
         }
+    }
+
+    public function test_place_order_with_offline_method_creates_the_order(): void
+    {
+        $customer = $this->createAuthenticatedCustomer();
+        $this->addProductToCart($customer);
+        $this->setCheckoutAddress($customer);
+        $this->setShippingMethod($customer);
+        $this->setPaymentMethod($customer, 'cashondelivery');
+
+        $response = $this->authenticatedPost($customer, $this->url);
+
+        $response->assertCreated();
+
+        $json = $response->json();
+
+        expect($json['redirect'])->toBeFalse();
+        expect($json['redirectUrl'])->toBeNull();
+        expect($json['orderId'])->not->toBeNull();
+
+        $this->assertDatabaseHas('orders', ['id' => (int) $json['orderId']]);
+    }
+
+    public function test_place_order_with_redirect_gateway_returns_redirect_and_creates_no_order(): void
+    {
+        $customer = $this->createAuthenticatedCustomer();
+        $this->addProductToCart($customer);
+        $this->setCheckoutAddress($customer);
+        $this->setShippingMethod($customer);
+        $this->setPaymentMethod($customer, 'stripe');
+
+        $ordersBefore = Order::count();
+
+        $response = $this->authenticatedPost($customer, $this->url);
+
+        $response->assertCreated();
+
+        $json = $response->json();
+
+        expect($json['redirect'])->toBeTrue();
+        expect($json['redirectUrl'])->toContain('/stripe/redirect');
+        expect($json['orderId'])->toBeNull();
+
+        expect(Order::count())->toBe($ordersBefore);
     }
 }

--- a/tests/Feature/RestApi/CheckoutShippingPaymentTest.php
+++ b/tests/Feature/RestApi/CheckoutShippingPaymentTest.php
@@ -150,6 +150,46 @@ class CheckoutShippingPaymentTest extends RestApiTestCase
         expect($json['paymentMethod'])->toBe('moneytransfer');
     }
 
+    public function test_redirect_gateway_returns_a_payment_gateway_url(): void
+    {
+        $customer = $this->createAuthenticatedCustomer();
+        $this->addProductToCart($customer);
+        $this->setAddress($customer);
+
+        $this->authenticatedPost($customer, '/api/shop/checkout-shipping-methods', [
+            'shippingMethod' => 'flatrate_flatrate',
+        ]);
+
+        foreach (['stripe' => '/stripe/redirect', 'phonepe' => '/phonepe/redirect'] as $method => $path) {
+            $response = $this->authenticatedPost($customer, '/api/shop/checkout-payment-methods', [
+                'paymentMethod' => $method,
+            ]);
+
+            $response->assertCreated();
+
+            expect($response->json('paymentGatewayUrl'))->toContain($path);
+        }
+    }
+
+    public function test_offline_method_returns_no_payment_gateway_url(): void
+    {
+        $customer = $this->createAuthenticatedCustomer();
+        $this->addProductToCart($customer);
+        $this->setAddress($customer);
+
+        $this->authenticatedPost($customer, '/api/shop/checkout-shipping-methods', [
+            'shippingMethod' => 'flatrate_flatrate',
+        ]);
+
+        $response = $this->authenticatedPost($customer, '/api/shop/checkout-payment-methods', [
+            'paymentMethod' => 'cashondelivery',
+        ]);
+
+        $response->assertCreated();
+
+        expect($response->json('paymentGatewayUrl'))->toBeNull();
+    }
+
     public function test_set_invalid_payment_method_returns_error(): void
     {
         $customer = $this->createAuthenticatedCustomer();

--- a/tests/Feature/RestApi/CustomizableOptionFileTest.php
+++ b/tests/Feature/RestApi/CustomizableOptionFileTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Testing\TestResponse;
+use Webkul\BagistoApi\Support\CartOptionFileStaging;
 use Webkul\BagistoApi\Tests\RestApiTestCase;
 use Webkul\Customer\Models\Customer;
 use Webkul\Product\Models\Product;
@@ -133,22 +134,40 @@ class CustomizableOptionFileTest extends RestApiTestCase
         expect($response->getStatusCode())->toBe(400);
     }
 
-    public function test_upload_rejects_a_file_over_the_size_limit(): void
+    /**
+     * The upload ceiling comes from php.ini (`upload_max_filesize`), the same central
+     * limit the rest of Bagisto uses — PHP rejects anything larger before the request
+     * reaches the endpoint, so the guard is asserted at the unit level.
+     */
+    public function test_upload_size_limit_comes_from_php_ini(): void
     {
-        config(['storefront.cart.customizable_file.max_size_kb' => 100]);
+        $staging = app(CartOptionFileStaging::class);
 
-        $customer = $this->createCustomer();
-        $product = $this->createSimpleProduct();
-        $optionId = $this->addFileOption($product);
+        $expected = $this->iniBytes((string) core()->getMaxUploadSize());
 
-        $response = $this->upload(
-            $customer,
-            $product->id,
-            $optionId,
-            UploadedFile::fake()->create('big.pdf', 200, 'application/pdf')
-        );
+        expect($staging->maxUploadBytes())->toBe($expected);
 
-        expect($response->getStatusCode())->toBe(400);
+        $oversized = new class extends CartOptionFileStaging
+        {
+            public function maxUploadBytes(): int
+            {
+                return 100 * 1024;
+            }
+        };
+
+        expect($oversized->maxUploadBytes())->toBeLessThan($staging->maxUploadBytes());
+    }
+
+    private function iniBytes(string $limit): int
+    {
+        $value = (int) $limit;
+
+        return match (strtoupper(substr(trim($limit), -1))) {
+            'G' => $value * 1024 ** 3,
+            'M' => $value * 1024 ** 2,
+            'K' => $value * 1024,
+            default => $value,
+        };
     }
 
     public function test_upload_returns_404_for_unknown_product(): void

--- a/tests/Feature/RestApi/MergeCartTest.php
+++ b/tests/Feature/RestApi/MergeCartTest.php
@@ -39,9 +39,11 @@ class MergeCartTest extends RestApiTestCase
 
     private function createGuestCartWithProduct(Product $product, int $qty = 1): array
     {
+        $this->flushHeaders();
+
         $tokenResponse = $this->publicPost($this->cartTokensUrl, ['createNew' => true]);
         $token = (string) ($tokenResponse->json('cartToken') ?? $tokenResponse->json('sessionToken'));
-        $this->assertNotEmpty($token);
+        $this->assertNotEmpty($token, 'Guest cart token missing from the cart-tokens response.');
 
         $addResponse = $this->postWithToken($this->addProductUrl, $token, [
             'productId' => $product->id,


### PR DESCRIPTION
## Bagisto-Api 2.4.1

- **Payments** — redirect gateways (Stripe, Razorpay, PayPal Standard, PhonePe) now return `paymentGatewayUrl`; place order returns the redirect instead of creating an unpaid order, and PhonePe no longer 500s.
- **Cart** — `cartToken` returns the cart's guest token instead of an id (null for a signed-in customer, who is addressed by their bearer token).
- **Exports** — every admin export accepts `?format=csv|xls|xlsx`, matching the admin panel; values are guarded against spreadsheet formula injection.
- **Catalog** — storefront category REST response carries `minPrice` / `maxPrice`, matching what GraphQL already exposed.
- **Swagger** — removed 30 phantom path params, dropped the required body on no-body actions, readable parameter descriptions, and request/response examples for all RMA + EU Withdrawal endpoints.
- **Docs playground** — the storefront key now survives `config:cache` / `optimize`, and Swagger UI honours the auto-inject setting.
- **Compatibility** — fixes GraphQL connection fields failing on some PHP-FPM servers, restores support for Bagisto cores below 2.4.5, and drops the hard Redis requirement (cache follows `CACHE_STORE`).
- **Versioning** — OpenAPI `info.version` now tracks the package version from a single constant; it had been stale at `1.0.4` for nine releases.
